### PR TITLE
feat: rework auth page, availability section, and async IMDB loading

### DIFF
--- a/src/components/media-details/media-availability.tsx
+++ b/src/components/media-details/media-availability.tsx
@@ -1,4 +1,25 @@
 import { component$ } from "@builder.io/qwik";
+import {
+  SiAmazonprime,
+  SiAppletv,
+  SiCrunchyroll,
+  SiFandango,
+  SiGoogleplay,
+  SiHbo,
+  SiHulu,
+  SiKinopoisk,
+  SiMubi,
+  SiNetflix,
+  SiPlex,
+  SiPrimevideo,
+  SiRakuten,
+  SiRoku,
+  SiShowtime,
+  SiSky,
+  SiStarz,
+  SiTubi,
+  SiYoutube,
+} from "@qwikest/icons/simpleicons";
 import type {
   LocalizedCertification,
   RegionalWatchProviders,
@@ -8,14 +29,10 @@ import {
   langAvailability,
   langCertification,
   langFree,
-  langOpenOnTmdb,
   langRegion,
-  langRent,
   langStream,
-  langSupportedByTmdb,
+  langText,
   langWatchWithAds,
-  langBuy,
-  langWhereToWatch,
 } from "~/utils/languages";
 
 type MediaAvailabilityProps = {
@@ -29,100 +46,221 @@ type ProviderGroup = {
   providers: WatchProvider[];
 };
 
+// Map TMDB provider_id to icon key
+const PROVIDER_ICON_BY_ID: Record<number, string> = {
+  2: "appletv",
+  3: "googleplay",
+  8: "netflix",
+  9: "amazonprime",
+  10: "amazonprime",
+  15: "hulu",
+  43: "starz",
+  37: "showtime",
+  73: "tubi",
+  119: "amazonprime",
+  188: "youtube",
+  192: "youtube",
+  337: "max",
+  350: "appletv",
+  384: "max",
+  531: "primevideo",
+  1899: "max",
+  283: "crunchyroll",
+  11: "mubi",
+  300: "plex",
+  546: "roku",
+  422: "fandango",
+  389: "fandango",
+  117: "rakuten",
+  167: "hbo",
+  30: "sky",
+  29: "sky",
+  68: "sky",
+  118: "kinopoisk",
+};
+
+// Fallback: match provider name to icon key
+const PROVIDER_ICON_BY_NAME: [RegExp, string][] = [
+  [/netflix/i, "netflix"],
+  [/prime video/i, "primevideo"],
+  [/amazon/i, "amazonprime"],
+  [/apple\s*tv/i, "appletv"],
+  [/google play/i, "googleplay"],
+  [/hulu/i, "hulu"],
+  [/\bmax\b/i, "max"],
+  [/hbo/i, "hbo"],
+  [/youtube/i, "youtube"],
+  [/crunchyroll/i, "crunchyroll"],
+  [/mubi/i, "mubi"],
+  [/plex/i, "plex"],
+  [/tubi/i, "tubi"],
+  [/roku/i, "roku"],
+  [/fandango/i, "fandango"],
+  [/starz/i, "starz"],
+  [/showtime/i, "showtime"],
+  [/rakuten/i, "rakuten"],
+  [/sky/i, "sky"],
+  [/kinopoisk/i, "kinopoisk"],
+  [/justwatch/i, "justwatch"],
+];
+
+const getProviderIconKey = (provider: WatchProvider): string | null => {
+  const byId = PROVIDER_ICON_BY_ID[provider.provider_id];
+  if (byId) return byId;
+  const name = provider.provider_name ?? "";
+  for (const [pattern, key] of PROVIDER_ICON_BY_NAME) {
+    if (pattern.test(name)) return key;
+  }
+  return null;
+};
+
+const ProviderIcon = component$<{ iconKey: string }>(({ iconKey }) => {
+  switch (iconKey) {
+    case "netflix":
+      return <SiNetflix />;
+    case "amazonprime":
+      return <SiAmazonprime />;
+    case "primevideo":
+      return <SiPrimevideo />;
+    case "appletv":
+      return <SiAppletv />;
+    case "googleplay":
+      return <SiGoogleplay />;
+    case "hulu":
+      return <SiHulu />;
+    case "max":
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M3.784 8.716c-.655 0-1.32.29-2.173.946v-.78H0v6.236h1.715V11.24c.749-.592 1.091-.78 1.372-.78c.333 0 .551.209.551.729v3.928h1.715V11.23c.748-.582 1.081-.769 1.372-.769c.333 0 .55.208.55.728v3.928H8.99v-4.53c0-1.403-.8-1.871-1.57-1.871c-.654 0-1.32.27-2.192.936c-.28-.697-.894-.936-1.444-.936m8.689 0c-1.705 0-3.118 1.466-3.118 3.284c0 1.82 1.413 3.285 3.118 3.285c.842 0 1.57-.312 2.131-.988v.82h1.632V8.883h-1.632v.822c-.561-.676-1.29-.988-2.131-.988zm4.064.166c.707 1.102 1.507 2.09 2.443 3.077a26.6 26.6 0 0 0-2.443 3.16h2.069a13.6 13.6 0 0 1 1.673-2.183a14 14 0 0 1 1.632 2.182H24a25 25 0 0 0-2.432-3.16A24 24 0 0 0 24 8.883h-2.047a14.7 14.7 0 0 1-1.674 2.11a13.4 13.4 0 0 1-1.674-2.11zm-3.804 1.279c1.018 0 1.84.82 1.84 1.84a1.837 1.837 0 0 1-1.84 1.839c-1.019 0-1.84-.82-1.84-1.84c0-1.018.821-1.84 1.84-1.84zm0 .415c-.78 0-1.414.633-1.414 1.423s.634 1.424 1.413 1.424c.78 0 1.414-.634 1.414-1.424s-.634-1.424-1.414-1.424z" />
+        </svg>
+      );
+    case "hbo":
+      return <SiHbo />;
+    case "youtube":
+      return <SiYoutube />;
+    case "crunchyroll":
+      return <SiCrunchyroll />;
+    case "mubi":
+      return <SiMubi />;
+    case "plex":
+      return <SiPlex />;
+    case "tubi":
+      return <SiTubi />;
+    case "roku":
+      return <SiRoku />;
+    case "fandango":
+      return <SiFandango />;
+    case "starz":
+      return <SiStarz />;
+    case "showtime":
+      return <SiShowtime />;
+    case "rakuten":
+      return <SiRakuten />;
+    case "sky":
+      return <SiSky />;
+    case "kinopoisk":
+      return <SiKinopoisk />;
+    case "justwatch":
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M11.727 11.7L8.1 9.85s-.646-.344-.617.38s0 3.591 0 3.591s-.1.767.612.427s3.094-1.571 3.627-1.841c.715-.367.005-.707.005-.707m-.006 5.023l-3.628-1.854s-.647-.345-.618.38s0 3.591 0 3.591s-.1.768.613.427s3.093-1.571 3.626-1.841c.717-.367.007-.703.007-.703m4.953-2.464l-3.628-1.854s-.647-.344-.617.38s-.005 3.591-.005 3.591s-.1.768.612.427s3.094-1.57 3.626-1.841c.722-.362.012-.703.012-.703m4.205-2.918L17.844 9.8c-.506-.257-.457.333-.457.333v3.824s-.054.564.468.3l3.025-1.526c1.398-.702-.001-1.39-.001-1.39m-4.203-2.229l-3.629-1.855s-.647-.343-.617.38s0 3.592 0 3.592s-.1.767.612.427s3.094-1.571 3.626-1.841c.717-.367.008-.703.008-.703M7.012 4.257s-1.494-.74-2.945-1.479s-1.539.693-1.539.693v3.128c0 .369.373.217.373.217s3.7-1.886 4.113-2.1s-.002-.459-.002-.459m1.071 4.924c.715-.34 3.094-1.57 3.626-1.841c.722-.366.013-.7.013-.7L8.093 4.783s-.646-.344-.618.38s0 3.591 0 3.591s-.107.768.608.427m-4.961 2.573c.716-.341 3.094-1.571 3.626-1.841c.723-.367.013-.7.013-.7L3.133 7.355s-.647-.343-.618.38s-.005 3.592-.005 3.592s-.103.767.612.427m-.005 4.954c.716-.34 3.094-1.57 3.627-1.841c.722-.366.012-.7.012-.7L3.128 12.31s-.647-.343-.618.38s0 3.591 0 3.591v.101c-.01.196.058.588.607.326M7 19.334c-.418-.216-4.115-2.1-4.115-2.1s-.374-.151-.373.218l.006 3.128s.09 1.434 1.54.692S7 19.791 7 19.791s.415-.24 0-.457" />
+        </svg>
+      );
+    default:
+      return null;
+  }
+});
+
+const deduplicateProviders = (providers: WatchProvider[]): WatchProvider[] => {
+  const seen = new Set<number>();
+  return providers.filter((p) => {
+    if (seen.has(p.provider_id)) return false;
+    seen.add(p.provider_id);
+    return true;
+  });
+};
+
 export const MediaAvailability = component$<MediaAvailabilityProps>(
   ({ certification, lang, watchProviders }) => {
+    const rentBuyProviders = watchProviders
+      ? deduplicateProviders([...watchProviders.rent, ...watchProviders.buy])
+      : [];
+
     const providerGroups: ProviderGroup[] = watchProviders
       ? [
+          { label: langStream(lang), providers: watchProviders.flatrate },
+          { label: langFree(lang), providers: watchProviders.free },
+          { label: langWatchWithAds(lang), providers: watchProviders.ads },
           {
-            label: langStream(lang),
-            providers: watchProviders.flatrate,
-          },
-          {
-            label: langFree(lang),
-            providers: watchProviders.free,
-          },
-          {
-            label: langWatchWithAds(lang),
-            providers: watchProviders.ads,
-          },
-          {
-            label: langRent(lang),
-            providers: watchProviders.rent,
-          },
-          {
-            label: langBuy(lang),
-            providers: watchProviders.buy,
+            label: langText(lang, "Rent / Buy", "Аренда / Покупка"),
+            providers: rentBuyProviders,
           },
         ].filter((group) => group.providers.length > 0)
       : [];
 
-    if (!certification && !watchProviders) {
+    if (!certification && providerGroups.length === 0) {
       return null;
     }
 
     return (
-      <section class="section-reveal card border-base-200 bg-base-100/95 border shadow-sm">
-        <div class="card-body gap-5">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div class="space-y-1">
-              <h3 class="card-title text-base-content/80 text-lg">
-                {langAvailability(lang)}
-              </h3>
-              <p class="text-base-content/60 text-sm">
-                {watchProviders
-                  ? `${langWhereToWatch(lang)} ${watchProviders.region}`
-                  : langSupportedByTmdb(lang)}
-              </p>
-            </div>
-            {watchProviders?.link && (
-              <a
-                href={watchProviders.link}
-                target="_blank"
-                rel="noreferrer"
-                class="btn btn-outline btn-sm"
-              >
-                {langOpenOnTmdb(lang)}
-              </a>
+      <section class="card border-base-200 bg-base-100/95 border shadow-sm">
+        <div class="card-body">
+          <h3 class="card-title text-base-content/80 text-lg">
+            {langAvailability(lang)}
+          </h3>
+
+          <section class="my-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-3 text-sm">
+            {certification && (
+              <>
+                <span class="leading-7 font-bold opacity-70">
+                  {langCertification(lang)}:
+                </span>
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="badge badge-outline badge-sm">
+                    {certification.rating}
+                  </span>
+                  <span class="opacity-70">
+                    {langRegion(lang)} {certification.region}
+                  </span>
+                </div>
+              </>
             )}
-          </div>
 
-          {certification && (
-            <div class="rounded-box border-base-300/70 bg-base-200/60 border p-4">
-              <div class="text-base-content/60 text-xs font-semibold tracking-[0.14em] uppercase">
-                {langCertification(lang)}
-              </div>
-              <div class="mt-2 flex flex-wrap items-center gap-2">
-                <span class="badge badge-secondary">
-                  {certification.rating}
+            {providerGroups.map((group) => (
+              <>
+                <span
+                  key={`${group.label}-label`}
+                  class="leading-7 font-bold opacity-70"
+                >
+                  {group.label}:
                 </span>
-                <span class="badge badge-ghost h-auto max-w-full gap-1 px-3 py-2 text-center leading-tight whitespace-normal">
-                  {langRegion(lang)} {certification.region}
-                </span>
-              </div>
-            </div>
-          )}
-
-          {providerGroups.length > 0 && (
-            <div class="space-y-4">
-              {providerGroups.map((group) => (
-                <div key={group.label} class="space-y-2">
-                  <div class="text-base-content/60 text-xs font-semibold tracking-[0.14em] uppercase">
-                    {group.label}
-                  </div>
-                  <div class="flex flex-wrap gap-2">
-                    {group.providers.map((provider) => (
+                <div
+                  key={group.label}
+                  class="flex flex-wrap items-center gap-2"
+                >
+                  {group.providers.map((provider) => {
+                    const iconKey = getProviderIconKey(provider);
+                    return iconKey ? (
+                      <div
+                        key={provider.provider_id}
+                        class="tooltip text-base-content/70 text-3xl"
+                        data-tip={provider.provider_name}
+                      >
+                        <ProviderIcon iconKey={iconKey} />
+                      </div>
+                    ) : (
                       <span
                         key={provider.provider_id}
-                        class="badge badge-soft badge-sm h-auto max-w-full px-3 py-2 text-center leading-tight whitespace-normal"
+                        class="badge badge-outline badge-sm"
                       >
                         {provider.provider_name}
                       </span>
-                    ))}
-                  </div>
+                    );
+                  })}
                 </div>
-              ))}
-            </div>
-          )}
+              </>
+            ))}
+          </section>
         </div>
       </section>
     );

--- a/src/components/media-details/media-rating.tsx
+++ b/src/components/media-details/media-rating.tsx
@@ -1,6 +1,8 @@
-import { component$ } from "@builder.io/qwik";
+import { component$, useSignal, useVisibleTask$ } from "@builder.io/qwik";
+import { server$ } from "@builder.io/qwik-city";
 
 import { RatingStar } from "~/components/rating-star";
+import { getOptionalImdbRating } from "~/services/cloud-func-api";
 import type { ImdbRating } from "~/services/models";
 import { formatRating } from "~/utils/format";
 import { Imdb } from "../imdb";
@@ -8,11 +10,32 @@ import { Imdb } from "../imdb";
 export type MediaRatingProps = {
   vote_average?: number;
   vote_count?: number;
-  imdb?: ImdbRating | null;
+  imdbId?: string | null;
 };
 
+const fetchImdbRating = server$(async (imdbId: string) => {
+  return getOptionalImdbRating(imdbId);
+});
+
 export const MediaRating = component$<MediaRatingProps>(
-  ({ vote_average, vote_count, imdb }) => {
+  ({ vote_average, vote_count, imdbId }) => {
+    const imdb = useSignal<ImdbRating | null>(null);
+    const loading = useSignal(!!imdbId);
+
+    // eslint-disable-next-line qwik/no-use-visible-task
+    useVisibleTask$(async () => {
+      if (!imdbId) {
+        loading.value = false;
+        return;
+      }
+      try {
+        const result = await fetchImdbRating(imdbId);
+        imdb.value = result ?? null;
+      } finally {
+        loading.value = false;
+      }
+    });
+
     return (
       <div class="flex items-center gap-2">
         {vote_average !== undefined && vote_average > 0 && (
@@ -28,7 +51,10 @@ export const MediaRating = component$<MediaRatingProps>(
             )}
           </div>
         )}
-        {imdb && <Imdb imdb={imdb} />}
+        {loading.value && (
+          <span class="loading loading-ring loading-sm" />
+        )}
+        {!loading.value && imdb.value && <Imdb imdb={imdb.value} />}
       </div>
     );
   },

--- a/src/components/media-details/movie-details.tsx
+++ b/src/components/media-details/movie-details.tsx
@@ -3,7 +3,6 @@ import { component$, useVisibleTask$ } from "@builder.io/qwik";
 import { DetailPageContainer } from "~/components/detail-page-layout";
 import {
   MediaType,
-  type ImdbRating,
   type LocalizedCertification,
   type MovieFull,
   type MovieShort,
@@ -40,7 +39,7 @@ interface MovieDetailsProps {
   movie: MovieFull;
   recMovies: MovieShort[];
   colMovies: MovieShort[];
-  imdb: ImdbRating | null;
+  imdbId?: string | null;
   certification: LocalizedCertification | null;
   watchProviders: RegionalWatchProviders | null;
   lang: string;
@@ -51,7 +50,7 @@ export const MovieDetails = component$(
     movie,
     recMovies,
     colMovies,
-    imdb,
+    imdbId,
     certification,
     watchProviders,
     lang,
@@ -112,7 +111,7 @@ export const MovieDetails = component$(
               <MediaRating
                 vote_average={movie.vote_average}
                 vote_count={movie.vote_count}
-                imdb={imdb}
+                imdbId={imdbId}
               />
             </div>
           </div>

--- a/src/components/media-details/tv-details.tsx
+++ b/src/components/media-details/tv-details.tsx
@@ -4,7 +4,6 @@ import { LuDisc3, LuLayers3 } from "@qwikest/icons/lucide";
 import { DetailPageContainer } from "~/components/detail-page-layout";
 import {
   MediaType,
-  type ImdbRating,
   type LocalizedCertification,
   type RegionalWatchProviders,
   type TvFull,
@@ -39,7 +38,7 @@ import { TvSeasons } from "./tv-seasons";
 interface TvDetailsProps {
   tv: TvFull;
   recTv: TvShort[];
-  imdb: ImdbRating | null;
+  imdbId?: string | null;
   certification: LocalizedCertification | null;
   watchProviders: RegionalWatchProviders | null;
   lang: string;
@@ -49,7 +48,7 @@ export const TvDetails = component$(
   ({
     tv,
     recTv,
-    imdb,
+    imdbId,
     certification,
     watchProviders,
     lang,
@@ -128,7 +127,7 @@ export const TvDetails = component$(
               <MediaRating
                 vote_average={tv.vote_average}
                 vote_count={tv.vote_count}
-                imdb={imdb}
+                imdbId={imdbId}
               />
             </div>
           </div>

--- a/src/routes/(auth-guard)/detail.route.test.ts
+++ b/src/routes/(auth-guard)/detail.route.test.ts
@@ -19,7 +19,7 @@ describe("detail route server data boundaries", () => {
     }
   });
 
-  it("renders IMDb data from loader results instead of a client-triggered fetch", async () => {
+  it("loads IMDb ratings lazily via server$ so detail pages render without blocking", async () => {
     const movieRouteSource = await readFile(
       join(import.meta.dir, "movie/[id]/index.tsx"),
       "utf8",
@@ -28,18 +28,15 @@ describe("detail route server data boundaries", () => {
       join(import.meta.dir, "tv/[id]/index.tsx"),
       "utf8",
     );
-    const imdbComponentSource = await readFile(
-      join(import.meta.dir, "../../components/imdb.tsx"),
+    const ratingComponentSource = await readFile(
+      join(import.meta.dir, "../../components/media-details/media-rating.tsx"),
       "utf8",
     );
 
-    expect(movieRouteSource).toContain("getOptionalImdbRating(movie.imdb_id)");
-    expect(tvRouteSource).toContain(
-      "getOptionalImdbRating(tv.external_ids.imdb_id)",
-    );
-    expect(imdbComponentSource).not.toContain("useOnDocument");
-    expect(imdbComponentSource).not.toContain("server$");
-    expect(imdbComponentSource).not.toContain("getImdbRating");
+    expect(movieRouteSource).not.toContain("getOptionalImdbRating");
+    expect(tvRouteSource).not.toContain("getOptionalImdbRating");
+    expect(ratingComponentSource).toContain("server$");
+    expect(ratingComponentSource).toContain("getOptionalImdbRating");
   });
 
   it("writes recent activity from browser-only visible tasks after resume", async () => {

--- a/src/routes/(auth-guard)/movie/[id]/index.tsx
+++ b/src/routes/(auth-guard)/movie/[id]/index.tsx
@@ -8,9 +8,7 @@ import {
   createDevMovieDetail,
   DEV_SESSION_BYPASS_COOKIE,
 } from "~/routes/dev-session";
-import { getOptionalImdbRating } from "~/services/cloud-func-api";
 import type {
-  ImdbRating,
   LocalizedCertification,
   MovieFull,
   MovieShort,
@@ -35,7 +33,6 @@ type MovieDetailData =
       movie: MovieFull;
       recMovies: MovieShort[];
       colMovies: MovieShort[];
-      imdb: ImdbRating | null;
       certification: LocalizedCertification | null;
       watchProviders: RegionalWatchProviders | null;
     }
@@ -77,7 +74,7 @@ export const useMovieDetailLoader = routeLoader$(async (event) => {
     });
     const region = getRegionFromLanguage(lang);
 
-    const [recMovies, colMovies, imdb, watchProviderResults] =
+    const [recMovies, colMovies, watchProviderResults] =
       await Promise.all([
         getMediaRecom({
           id,
@@ -91,7 +88,6 @@ export const useMovieDetailLoader = routeLoader$(async (event) => {
               language: lang,
             })
           : Promise.resolve([] as MovieShort[]),
-        getOptionalImdbRating(movie.imdb_id),
         getOptionalWatchProviders({
           id,
           type: MediaType.Movie,
@@ -104,7 +100,6 @@ export const useMovieDetailLoader = routeLoader$(async (event) => {
       movie,
       recMovies,
       colMovies,
-      imdb,
       certification: resolveMovieCertification(movie.release_dates, region),
       watchProviders: resolveRegionalWatchProviders(
         watchProviderResults,
@@ -146,7 +141,7 @@ export default component$(() => {
         movie={value.movie}
         recMovies={value.recMovies}
         colMovies={value.colMovies}
-        imdb={value.imdb}
+        imdbId={value.movie.imdb_id}
         certification={value.certification}
         watchProviders={value.watchProviders}
         lang={value.lang}

--- a/src/routes/(auth-guard)/tv/[id]/index.tsx
+++ b/src/routes/(auth-guard)/tv/[id]/index.tsx
@@ -8,9 +8,7 @@ import {
   createDevTvDetail,
   DEV_SESSION_BYPASS_COOKIE,
 } from "~/routes/dev-session";
-import { getOptionalImdbRating } from "~/services/cloud-func-api";
 import type {
-  ImdbRating,
   LocalizedCertification,
   RegionalWatchProviders,
   TvFull,
@@ -33,7 +31,6 @@ type TvDetailData =
       lang: string;
       tv: TvFull;
       recTv: TvShort[];
-      imdb: ImdbRating | null;
       certification: LocalizedCertification | null;
       watchProviders: RegionalWatchProviders | null;
     }
@@ -75,14 +72,13 @@ export const useTvDetailLoader = routeLoader$(async (event) => {
     });
     const region = getRegionFromLanguage(lang);
 
-    const [recTv, imdb, watchProviderResults] = await Promise.all([
+    const [recTv, watchProviderResults] = await Promise.all([
       getMediaRecom({
         id,
         language: lang,
         type: MediaType.Tv,
         query: "recommendations",
       }) as Promise<TvShort[]>,
-      getOptionalImdbRating(tv.external_ids.imdb_id),
       getOptionalWatchProviders({
         id,
         type: MediaType.Tv,
@@ -94,7 +90,6 @@ export const useTvDetailLoader = routeLoader$(async (event) => {
       lang,
       tv,
       recTv,
-      imdb,
       certification: resolveTvCertification(tv.content_ratings, region),
       watchProviders: resolveRegionalWatchProviders(
         watchProviderResults,
@@ -135,7 +130,7 @@ export default component$(() => {
       <TvDetails
         tv={value.tv}
         recTv={value.recTv}
-        imdb={value.imdb}
+        imdbId={value.tv.external_ids.imdb_id}
         certification={value.certification}
         watchProviders={value.watchProviders}
         lang={value.lang}

--- a/src/routes/auth/index.tsx
+++ b/src/routes/auth/index.tsx
@@ -26,6 +26,7 @@ export default component$(() => {
   const authFeatureCards = [
     {
       copy: langFastSearchDescription(lang),
+      icon: "M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803a7.5 7.5 0 0010.607 0z",
       index: "01",
       title: langFastSearch(lang),
       toneClass:
@@ -33,6 +34,7 @@ export default component$(() => {
     },
     {
       copy: langClearDetailsDescription(lang),
+      icon: "M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12",
       index: "02",
       title: langClearDetails(lang),
       toneClass:
@@ -40,6 +42,7 @@ export default component$(() => {
     },
     {
       copy: langOneWatchlistDescription(lang),
+      icon: "M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z",
       index: "03",
       title: langOneWatchlist(lang),
       toneClass:
@@ -49,22 +52,35 @@ export default component$(() => {
 
   return (
     <div class="bg-base-100 page-enter relative min-h-screen overflow-hidden">
+      {/* Dot pattern */}
       <div
-        class="pointer-events-none absolute inset-0 opacity-60"
+        class="pointer-events-none absolute inset-0 opacity-40"
         style={{
           backgroundImage:
-            "radial-gradient(circle at 1px 1px, oklch(58% 0.02 250 / 0.22) 1px, transparent 0)",
-          backgroundSize: "26px 26px",
+            "radial-gradient(circle at 1px 1px, oklch(58% 0.02 250 / 0.18) 1px, transparent 0)",
+          backgroundSize: "32px 32px",
         }}
       />
+
+      {/* Animated gradient blobs */}
       <div class="pointer-events-none absolute inset-0">
-        <div class="absolute -top-40 -left-32 h-112 w-md rounded-full bg-(--auth-blob-one) blur-[120px]" />
-        <div class="absolute top-[24%] -right-32 h-96 w-96 rounded-full bg-(--auth-blob-two) blur-[120px]" />
-        <div class="absolute -bottom-48 left-[30%] h-96 w-96 rounded-full bg-(--auth-blob-three) blur-[130px]" />
+        <div
+          class="absolute -top-32 left-1/2 h-[480px] w-[600px] -translate-x-1/2 rounded-full bg-(--auth-blob-one) blur-[140px]"
+          style={{ animation: "pulse 8s ease-in-out infinite" }}
+        />
+        <div
+          class="absolute top-[40%] -right-40 h-80 w-80 rounded-full bg-(--auth-blob-two) blur-[120px]"
+          style={{ animation: "pulse 10s ease-in-out 2s infinite" }}
+        />
+        <div
+          class="absolute -bottom-32 -left-20 h-72 w-96 rounded-full bg-(--auth-blob-three) blur-[130px]"
+          style={{ animation: "pulse 9s ease-in-out 4s infinite" }}
+        />
       </div>
 
       <div class="relative z-10 flex min-h-screen flex-col">
-        <header class="section-reveal mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-6">
+        {/* Header */}
+        <header class="section-reveal mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-6">
           <div class="flex items-center gap-3">
             <div class="border-base-300/70 bg-base-100/85 rounded-2xl border p-2 shadow-sm backdrop-blur-sm">
               <HiFilmOutline class="text-primary text-xl" />
@@ -73,108 +89,123 @@ export default component$(() => {
               Moviestracker
             </span>
           </div>
-          <span class="badge border-base-300/80 bg-base-100/85 h-9 rounded-xl px-4 text-[0.8rem] font-medium backdrop-blur-sm">
+          <span class="badge badge-sm border-base-300/80 bg-base-100/85 h-8 rounded-xl px-3.5 text-[0.78rem] font-medium backdrop-blur-sm">
             {langPersonalWatchlist(lang)}
           </span>
         </header>
 
+        {/* Hero - centered layout */}
         <main
           id="main-content"
-          class="mx-auto grid w-full max-w-7xl flex-1 grid-cols-1 gap-10 px-6 pb-10 lg:grid-cols-[1.18fr_0.82fr] lg:items-center lg:gap-16"
+          class="mx-auto flex w-full max-w-4xl flex-1 flex-col items-center justify-center px-6 pb-16 pt-8 text-center lg:pb-20 lg:pt-4"
         >
-          <section class="space-y-7">
-            <div class="section-reveal badge bg-base-200/80 h-9 rounded-xl border-0 px-4 text-xs font-semibold tracking-[0.08em] uppercase">
-              {langPrivateMovieHub(lang)}
-            </div>
-            <h1
-              class="section-reveal text-base-content text-4xl leading-[1.04] font-black tracking-tight md:text-6xl xl:text-7xl"
-              style={{ "--motion-delay": "80ms" }}
-            >
-              {langTrackMoviesAndTvShowsPrefix(lang)}
-              <br class="hidden lg:block" />{" "}
-              <span class="from-(--auth-accent-from)via-[color:var(--auth-accent-via)] bg-linear-to-r to-(--auth-accent-to) bg-clip-text text-transparent">
-                {langTrackMoviesAndTvShowsAccent(lang)}
-              </span>
-            </h1>
-            <p
-              class="section-reveal text-base-content/70 max-w-2xl text-lg leading-relaxed md:text-xl"
-              style={{ "--motion-delay": "140ms" }}
-            >
-              {langSimplePlaceToDiscoverTitles(lang)}
-            </p>
-            <div
-              class="section-reveal flex flex-wrap items-center gap-3 pt-2"
-              style={{ "--motion-delay": "180ms" }}
-            >
-              <LoginButton
-                lang={lang}
-                providerName="google"
-                class="h-14 rounded-2xl border-0 bg-linear-to-r from-(--auth-primary-from) to-(--auth-primary-to) px-7 text-base font-semibold text-white shadow-[0_18px_42px_var(--auth-primary-shadow)] hover:from-(--auth-primary-from-hover) hover:to-(--auth-primary-to-hover)"
-              >
-                <svg
-                  aria-label={langGoogleLogo(lang)}
-                  width="24"
-                  height="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 512 512"
-                >
-                  <g>
-                    <path d="m0 0H512V512H0" fill="#fff"></path>
-                    <path
-                      fill="#34a853"
-                      d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"
-                    ></path>
-                    <path
-                      fill="#4285f4"
-                      d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"
-                    ></path>
-                    <path
-                      fill="#fbbc02"
-                      d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"
-                    ></path>
-                    <path
-                      fill="#ea4335"
-                      d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"
-                    ></path>
-                  </g>
-                </svg>
-              </LoginButton>
-            </div>
-          </section>
-
-          <section
-            class="section-reveal border-base-200/80 bg-base-100/86 shadow-base-content/7 mx-auto w-full max-w-md rounded-3xl border p-6 shadow-2xl backdrop-blur-md sm:p-7"
-            style={{ "--motion-delay": "120ms" }}
+          <div
+            class="section-reveal badge badge-sm bg-base-200/80 mb-6 h-8 rounded-xl border-0 px-4 text-xs font-semibold tracking-[0.08em] uppercase"
           >
-            <div class="mb-6 flex items-center justify-between">
-              <div class="text-base-content text-lg font-bold tracking-tight">
+            {langPrivateMovieHub(lang)}
+          </div>
+
+          <h1
+            class="section-reveal text-base-content mb-6 text-5xl leading-[1.02] font-black tracking-tight md:text-7xl lg:text-8xl"
+            style={{ "--motion-delay": "80ms" }}
+          >
+            {langTrackMoviesAndTvShowsPrefix(lang)}{" "}
+            <span class="from-(--auth-accent-from) via-[color:var(--auth-accent-via)] bg-linear-to-r to-(--auth-accent-to) bg-clip-text text-transparent">
+              {langTrackMoviesAndTvShowsAccent(lang)}
+            </span>
+          </h1>
+
+          <p
+            class="section-reveal text-base-content/65 mb-10 max-w-xl text-lg leading-relaxed md:text-xl"
+            style={{ "--motion-delay": "140ms" }}
+          >
+            {langSimplePlaceToDiscoverTitles(lang)}
+          </p>
+
+          <div
+            class="section-reveal mb-20"
+            style={{ "--motion-delay": "180ms" }}
+          >
+            <LoginButton
+              lang={lang}
+              providerName="google"
+              class="h-14 rounded-2xl border-0 bg-linear-to-r from-(--auth-primary-from) to-(--auth-primary-to) px-8 text-base font-semibold text-white shadow-[0_20px_50px_var(--auth-primary-shadow)] transition-all duration-200 hover:scale-[1.02] hover:from-(--auth-primary-from-hover) hover:to-(--auth-primary-to-hover) hover:shadow-[0_24px_56px_var(--auth-primary-shadow)]"
+            >
+              <svg
+                aria-label={langGoogleLogo(lang)}
+                width="24"
+                height="24"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+              >
+                <g>
+                  <path d="m0 0H512V512H0" fill="#fff"></path>
+                  <path
+                    fill="#34a853"
+                    d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"
+                  ></path>
+                  <path
+                    fill="#4285f4"
+                    d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"
+                  ></path>
+                  <path
+                    fill="#fbbc02"
+                    d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"
+                  ></path>
+                  <path
+                    fill="#ea4335"
+                    d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"
+                  ></path>
+                </g>
+              </svg>
+            </LoginButton>
+          </div>
+
+          {/* Feature cards section */}
+          <section
+            class="section-reveal w-full max-w-4xl"
+            style={{ "--motion-delay": "240ms" }}
+          >
+            <div class="mb-8 flex items-center justify-center gap-3">
+              <span class="text-base-content text-base font-bold tracking-tight">
                 {langWhyPeopleUseIt(lang)}
-              </div>
-              <span class="badge border-0 bg-(--auth-badge-bg) text-[0.7rem] font-semibold text-white uppercase">
+              </span>
+              <span class="badge badge-sm border-0 bg-(--auth-badge-bg) text-[0.68rem] font-semibold text-white uppercase">
                 {langNew(lang)}
               </span>
             </div>
 
-            <div class="grid gap-4 text-sm">
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-5">
               {authFeatureCards.map((feature) => (
                 <article
                   key={feature.index}
-                  class="border-base-200 bg-base-200/45 rounded-2xl border p-4"
+                  class="border-base-200/80 bg-base-100/70 group rounded-2xl border p-5 backdrop-blur-md transition-all duration-200 hover:shadow-lg"
                 >
-                  <div class="mb-2 flex items-center gap-3">
+                  <div class="mb-3 flex items-center gap-3">
                     <span
                       class={[
-                        "grid h-9 w-9 place-items-center rounded-xl text-sm font-bold",
+                        "grid h-10 w-10 place-items-center rounded-xl text-sm font-bold",
                         feature.toneClass,
                       ]}
                     >
-                      {feature.index}
+                      <svg
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d={feature.icon} />
+                      </svg>
                     </span>
-                    <p class="text-base-content text-base font-bold">
+                    <p class="text-base-content text-[0.95rem] font-bold">
                       {feature.title}
                     </p>
                   </div>
-                  <p class="text-base-content/70 leading-relaxed">
+                  <p class="text-base-content/60 text-sm leading-relaxed">
                     {feature.copy}
                   </p>
                 </article>
@@ -183,9 +214,10 @@ export default component$(() => {
           </section>
         </main>
 
+        {/* Footer */}
         <footer class="border-base-200/70 bg-base-100/70 border-t backdrop-blur-sm">
-          <div class="text-base-content/65 mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-3 px-6 py-4 text-sm">
-            <p>© 2026 Moviestracker</p>
+          <div class="text-base-content/55 mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-6 py-4 text-sm">
+            <p>&copy; 2026 Moviestracker</p>
             <p>{langPrivateCatalogAccessForSignedInUsers(lang)}</p>
           </div>
         </footer>

--- a/src/routes/dev-session.test.ts
+++ b/src/routes/dev-session.test.ts
@@ -92,7 +92,6 @@ describe("dev session bypass", () => {
     expect(fixture?.movie.title).toBe("Playwright in Paris");
     expect(fixture?.lang).toBe("en-US");
     expect(fixture?.recMovies).toHaveLength(1);
-    expect(fixture?.imdb?.Id).toBe("tt9900010");
     expect(fixture?.certification?.rating).toBe("PG-13");
     expect(fixture?.watchProviders?.flatrate[0]?.provider_name).toBe("Netflix");
   });
@@ -133,7 +132,6 @@ describe("dev session bypass", () => {
 
     expect(fixture?.tv.name).toBe("Selectors");
     expect(fixture?.recTv[0]?.name).toBe("State Machines");
-    expect(fixture?.imdb?.Id).toBe("tt9901010");
     expect(fixture?.certification?.rating).toBe("TV-14");
     expect(fixture?.watchProviders?.flatrate[0]?.provider_name).toBe("Hulu");
   });

--- a/src/routes/dev-session.ts
+++ b/src/routes/dev-session.ts
@@ -2,7 +2,6 @@ import type { Session } from "@auth/core/types";
 import {
   type LocalizedCertification,
   MediaType,
-  type ImdbRating,
   type MovieFull,
   type MovieMongo,
   type MovieShort,
@@ -94,7 +93,6 @@ type DevMovieDetailFixture = {
   movie: MovieFull;
   recMovies: MovieShort[];
   colMovies: MovieShort[];
-  imdb: ImdbRating | null;
   certification: LocalizedCertification | null;
   watchProviders: RegionalWatchProviders | null;
 };
@@ -110,7 +108,6 @@ type DevTvDetailFixture = {
   lang: string;
   tv: TvFull;
   recTv: TvShort[];
-  imdb: ImdbRating | null;
   certification: LocalizedCertification | null;
   watchProviders: RegionalWatchProviders | null;
 };
@@ -187,12 +184,6 @@ const DEV_MOVIE_RECOMMENDATIONS = [
     vote_average: 7.1,
   },
 ] satisfies MovieShort[];
-
-const DEV_MOVIE_IMDB = {
-  Id: "tt9900010",
-  Rating: "7.9",
-  Votes: "128,400",
-} satisfies ImdbRating;
 
 const DEV_MOVIE_CERTIFICATION = {
   rating: "PG-13",
@@ -357,12 +348,6 @@ const DEV_TV_RECOMMENDATIONS = [
   },
 ] satisfies TvShort[];
 
-const DEV_TV_IMDB = {
-  Id: "tt9901010",
-  Rating: "7.7",
-  Votes: "94,000",
-} satisfies ImdbRating;
-
 const DEV_TV_CERTIFICATION = {
   rating: "TV-14",
   region: "US",
@@ -485,7 +470,6 @@ export const createDevMovieDetail = ({
     movie: DEV_MOVIE_DETAIL,
     recMovies: DEV_MOVIE_RECOMMENDATIONS,
     colMovies: [],
-    imdb: DEV_MOVIE_IMDB,
     certification: DEV_MOVIE_CERTIFICATION,
     watchProviders: DEV_MOVIE_WATCH_PROVIDERS,
   };
@@ -540,7 +524,6 @@ export const createDevTvDetail = ({
     lang,
     tv: DEV_TV_DETAIL,
     recTv: DEV_TV_RECOMMENDATIONS,
-    imdb: DEV_TV_IMDB,
     certification: DEV_TV_CERTIFICATION,
     watchProviders: DEV_TV_WATCH_PROVIDERS,
   };


### PR DESCRIPTION
## Summary
- **Auth page**: Centered hero layout with larger title, horizontal feature cards with SVG icons, refined gradient blobs, and `badge-sm` consistency
- **Availability section**: Compact 2-column grid matching Production Details style, Simple Icons for streaming providers with daisyUI tooltips, combined Rent/Buy row, all links removed
- **Async IMDB ratings**: Removed blocking `getOptionalImdbRating` from route loaders; ratings now load lazily via `server$` + `useVisibleTask$` with a loading spinner

## Test plan
- [ ] Verify /auth page renders correctly with centered layout and feature cards
- [ ] Verify movie detail page loads immediately without waiting for IMDB rating
- [ ] Verify TV detail page loads immediately without waiting for IMDB rating
- [ ] Verify IMDB rating appears after loading spinner on both detail pages
- [ ] Verify availability section shows provider icons with tooltips
- [ ] Verify certification badge uses `badge-sm`
- [ ] Verify Rent/Buy providers are combined in one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)