### PR TITLE
fix: restore auth host trust in production

### DIFF
--- a/src/routes/auth-config.test.ts
+++ b/src/routes/auth-config.test.ts
@@ -47,14 +47,14 @@ describe("auth config secret resolution", () => {
     ).toBe("real-secret");
   });
 
-  it("does not trust host headers when AUTH_URL pins production origin", () => {
+  it("trusts host handling when AUTH_URL pins production origin", () => {
     expect(
       resolveAuthTrustHost({
         authUrl: "https://movies.example.com/auth",
         lifecycleEvent: "start",
         nodeEnv: "production",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("keeps local and build auth host ergonomics without AUTH_URL", () => {

--- a/src/routes/auth-config.ts
+++ b/src/routes/auth-config.ts
@@ -79,7 +79,7 @@ export const resolveAuthTrustHost = ({
   nodeEnv,
 }: Omit<AuthSecretContext, "authSecret"> & { authUrl?: string | null }) => {
   if (normalizeOrigin(authUrl)) {
-    return false;
+    return true;
   }
 
   if (isBuildSafeAuthContext({ lifecycleEvent, nodeEnv })) {


### PR DESCRIPTION
## Summary
- stop forcing `trustHost` to `false` when `AUTH_URL` is configured
- keep request-origin pinning in place and align auth tests with runtime behavior

## Verification
- bun test src/routes/auth-config.test.ts src/request-origin.test.ts
- bun run build.types
- bun run lint
- bun run build