### PR TITLE
Integrate JacRed torrent search

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -66,6 +66,7 @@
 
 - TMDB client: `src/services/tmdb.ts`
 - Cloud gateway client: `src/services/cloud-func-api.ts`
+- JacRed torrent-search adapter: `src/services/torrent-search.ts`
 - MongoDB Atlas reads: `src/services/mongoatlas.ts`
 - TorrServer client: `src/services/torrserver.ts`
 - Mongo client init and reuse: `src/utils/mongodbinit.ts`

--- a/src/components/torrent-list.tsx
+++ b/src/components/torrent-list.tsx
@@ -1,11 +1,25 @@
-import { $, component$, useStore, useTask$ } from "@builder.io/qwik";
+import {
+  $,
+  component$,
+  useOnDocument,
+  useSignal,
+  useStore,
+  useTask$,
+} from "@builder.io/qwik";
 import { server$ } from "@builder.io/qwik-city";
 import { setValue, useForm } from "@modular-forms/qwik";
 import { HiMagnifyingGlassOutline } from "@qwikest/icons/heroicons";
-import type { getTorrentsType } from "~/services/cloud-func-api";
-import { getTorrents } from "~/services/cloud-func-api";
 import type { MovieDetails, Torrent } from "~/services/models";
+import {
+  getTorrentSearch,
+  type getTorrentsType,
+} from "~/services/torrent-search";
 import { filterAndSortTorrents } from "~/utils/filter-utils";
+import {
+  getDynamicRangeLabel,
+  getTorrentDynamicRangeValue,
+  type DynamicRangeFilter,
+} from "~/utils/torrent-format";
 import {
   langDate,
   langFound,
@@ -14,6 +28,7 @@ import {
   langSeeds,
   langSize,
   langSortOn,
+  langText,
   langTorrentov,
 } from "~/utils/languages";
 import { TorrentBlock } from "./torrent";
@@ -23,7 +38,126 @@ type SearchTorrForm = {
   year: number;
 };
 
-type FilterKey = "k4" | "hdr" | "hdr10" | "hdr10plus" | "dv";
+type SelectFilterKey =
+  | "category"
+  | "dynamicRange"
+  | "quality"
+  | "season"
+  | "tracker"
+  | "voice";
+type ClearableFilterKey =
+  | "category"
+  | "dynamicRange"
+  | "quality"
+  | "season"
+  | "tracker"
+  | "voice";
+
+type TorrentFilterOption = {
+  count: number;
+  label: string;
+  value: string;
+};
+
+const addOption = (
+  options: Map<string, TorrentFilterOption>,
+  value: null | number | string | undefined,
+  label?: null | string,
+) => {
+  if (value === null || value === undefined || value === "") {
+    return;
+  }
+
+  const key = String(value);
+  const current = options.get(key);
+  options.set(key, {
+    count: (current?.count ?? 0) + 1,
+    label: current?.label || label || key,
+    value: key,
+  });
+};
+
+const sortOptions = (options: Map<string, TorrentFilterOption>) =>
+  [...options.values()].sort((left, right) =>
+    left.label.localeCompare(right.label),
+  );
+
+const getTrackerOptions = (torrents: Torrent[] | null) => {
+  const options = new Map<string, TorrentFilterOption>();
+  for (const torrent of torrents ?? []) {
+    addOption(options, torrent.Tracker);
+  }
+  return sortOptions(options);
+};
+
+const getQualityOptions = (torrents: Torrent[] | null) => {
+  const options = new Map<string, TorrentFilterOption>();
+  for (const torrent of torrents ?? []) {
+    if (torrent.Quality) {
+      addOption(
+        options,
+        torrent.Quality,
+        torrent.QualityLabel || `${torrent.Quality}p`,
+      );
+      continue;
+    }
+
+    if (torrent.K4) {
+      addOption(options, 2160, "4K");
+    } else if (torrent.FHD) {
+      addOption(options, 1080, "1080p");
+    }
+  }
+  return [...options.values()].sort(
+    (left, right) => Number(right.value) - Number(left.value),
+  );
+};
+
+const getDynamicRangeOptions = (torrents: Torrent[] | null) => {
+  const options = new Map<string, TorrentFilterOption>();
+  for (const torrent of torrents ?? []) {
+    const value = getTorrentDynamicRangeValue(torrent);
+    addOption(options, value, getDynamicRangeLabel(value));
+  }
+  const order: DynamicRangeFilter[] = ["dv", "hdr10plus", "hdr10", "hdr"];
+  return [...options.values()].sort(
+    (left, right) =>
+      order.indexOf(left.value as DynamicRangeFilter) -
+      order.indexOf(right.value as DynamicRangeFilter),
+  );
+};
+
+const getVoiceOptions = (torrents: Torrent[] | null) => {
+  const options = new Map<string, TorrentFilterOption>();
+  for (const torrent of torrents ?? []) {
+    for (const voice of torrent.Voices ?? []) {
+      addOption(options, voice);
+    }
+  }
+  return sortOptions(options);
+};
+
+const getCategoryOptions = (torrents: Torrent[] | null) => {
+  const options = new Map<string, TorrentFilterOption>();
+  for (const torrent of torrents ?? []) {
+    for (const [index, category] of (torrent.Categories ?? []).entries()) {
+      addOption(options, category, torrent.CategoryLabels?.[index] ?? category);
+    }
+  }
+  return sortOptions(options);
+};
+
+const getSeasonOptions = (torrents: Torrent[] | null) => {
+  const options = new Map<string, TorrentFilterOption>();
+  for (const torrent of torrents ?? []) {
+    for (const optionSeason of torrent.Seasons ?? []) {
+      addOption(options, optionSeason, `S${optionSeason}`);
+    }
+  }
+  return [...options.values()].sort(
+    (left, right) => Number(left.value) - Number(right.value),
+  );
+};
 
 export type TorrentListProps = {
   torrents: Torrent[] | null;
@@ -32,10 +166,23 @@ export type TorrentListProps = {
   isMovie: boolean;
   movie: MovieDetails;
   lang: string;
+  season?: number;
+  sourceLoaded?: number;
+  sourceTotal?: number;
 };
 
 export const TorrentList = component$(
-  ({ torrents, isMovie, title, year, movie, lang }: TorrentListProps) => {
+  ({
+    torrents,
+    isMovie,
+    title,
+    year,
+    movie,
+    lang,
+    season,
+    sourceLoaded = 0,
+    sourceTotal = 0,
+  }: TorrentListProps) => {
     const titlePlaceholder = lang === "en-US" ? "title" : "название";
     const yearPlaceholder = lang === "en-US" ? "year" : "год";
     const resetFiltersLabel =
@@ -47,24 +194,23 @@ export const TorrentList = component$(
       { value: "Seeds", text: langSeeds(lang) },
       { value: "Leeches", text: langLeeches(lang) },
     ];
-    const filterOptions: Array<{ key: FilterKey; label: string }> = [
-      { key: "k4", label: "4K" },
-      { key: "hdr", label: "HDR" },
-      { key: "hdr10", label: "HDR10" },
-      { key: "hdr10plus", label: "HDR10+" },
-      { key: "dv", label: "DV" },
-    ];
-
     const initTorrents = useStore({ value: torrents as Torrent[] | null });
+    const sourceStats = useStore({
+      loaded: sourceLoaded,
+      total: sourceTotal,
+    });
+    const formatDropdownRef = useSignal<HTMLElement>();
     const sortedTorrents = useStore({ value: null as Torrent[] | null });
     const sortFilterStore = useStore({
       selectedSort: "Date" as string,
       filterChecked: false as boolean,
-      k4: false as boolean,
-      hdr: false as boolean,
-      hdr10: false as boolean,
-      hdr10plus: false as boolean,
-      dv: false as boolean,
+      category: "" as string,
+      dynamicRange: "" as string,
+      quality: "" as string,
+      season: "" as string,
+      tracker: "" as string,
+      videoType: "" as string,
+      voice: "" as string,
     });
 
     const filterTorrents = $(() => {
@@ -82,14 +228,22 @@ export const TorrentList = component$(
       sortFilterStore.selectedSort = value;
       touchFilters();
     });
-    const setFilter = $((key: FilterKey, checked: boolean) => {
-      sortFilterStore[key] = checked;
+    const setSelectFilter = $((key: SelectFilterKey, value: string) => {
+      sortFilterStore[key] = value;
+      touchFilters();
+    });
+    const clearSelectFilter = $((key: ClearableFilterKey) => {
+      sortFilterStore[key] = "";
       touchFilters();
     });
     const resetFilters = $(() => {
-      for (const { key } of filterOptions) {
-        sortFilterStore[key] = false;
-      }
+      sortFilterStore.category = "";
+      sortFilterStore.dynamicRange = "";
+      sortFilterStore.quality = "";
+      sortFilterStore.season = "";
+      sortFilterStore.tracker = "";
+      sortFilterStore.videoType = "";
+      sortFilterStore.voice = "";
       touchFilters();
     });
 
@@ -100,21 +254,24 @@ export const TorrentList = component$(
     const handleSubmit = $(async (values: SearchTorrForm) => {
       sortedTorrents.value = null;
       try {
-        const torrents = await server$(
-          ({ name, year, isMovie }: getTorrentsType) => {
-            return getTorrents({ name: name, year: year, isMovie: isMovie });
-          },
+        const result = await server$(
+          (request: getTorrentsType) => getTorrentSearch(request),
         )({
           name: values.name,
           year: values.year,
           isMovie: isMovie,
+          season,
         });
-        if (torrents.length > 0) {
-          initTorrents.value = torrents;
+        sourceStats.loaded = result.loaded;
+        sourceStats.total = result.total;
+        if (result.torrents.length > 0) {
+          initTorrents.value = result.torrents;
           return;
         }
+        initTorrents.value = [];
       } catch (error) {
         console.error(error);
+        initTorrents.value = [];
         sortedTorrents.value = [];
       }
 
@@ -133,10 +290,110 @@ export const TorrentList = component$(
     });
 
     useTask$((ctx) => {
+      ctx.track(() => sourceLoaded);
+      ctx.track(() => sourceTotal);
+      sourceStats.loaded = sourceLoaded;
+      sourceStats.total = sourceTotal;
+    });
+
+    useTask$((ctx) => {
       ctx.track(() => initTorrents.value);
       ctx.track(() => sortFilterStore.filterChecked);
       filterTorrents();
     });
+
+    useOnDocument(
+      "click",
+      $((event) => {
+        const dropdown = formatDropdownRef.value;
+        const target = event.target;
+        if (!(target instanceof Node) || !dropdown?.contains(target)) {
+          dropdown?.removeAttribute("open");
+        }
+      }),
+    );
+
+    const qualityOptions = getQualityOptions(initTorrents.value);
+    const dynamicRangeOptions = getDynamicRangeOptions(initTorrents.value);
+    const trackerOptions = getTrackerOptions(initTorrents.value);
+    const voiceOptions = getVoiceOptions(initTorrents.value);
+    const categoryOptions = getCategoryOptions(initTorrents.value);
+    const seasonOptions = getSeasonOptions(initTorrents.value);
+    const formatLabelParts = [
+      qualityOptions.find((option) => option.value === sortFilterStore.quality)
+        ?.label,
+      getDynamicRangeLabel(sortFilterStore.dynamicRange as DynamicRangeFilter),
+    ].filter(Boolean);
+    const activeFilterCandidates: Array<{
+      key: ClearableFilterKey;
+      label: string;
+      value: string;
+    }> = [
+      {
+        key: "quality",
+        label:
+          qualityOptions.find(
+            (option) => option.value === sortFilterStore.quality,
+          )?.label ?? "",
+        value: sortFilterStore.quality,
+      },
+      {
+        key: "dynamicRange",
+        label: getDynamicRangeLabel(
+          sortFilterStore.dynamicRange as DynamicRangeFilter,
+        ),
+        value: sortFilterStore.dynamicRange,
+      },
+      {
+        key: "tracker",
+        label: sortFilterStore.tracker,
+        value: sortFilterStore.tracker,
+      },
+      {
+        key: "voice",
+        label: sortFilterStore.voice,
+        value: sortFilterStore.voice,
+      },
+      {
+        key: "category",
+        label:
+          categoryOptions.find(
+            (option) => option.value === sortFilterStore.category,
+          )?.label ?? "",
+        value: sortFilterStore.category,
+      },
+      {
+        key: "season",
+        label:
+          seasonOptions.find(
+            (option) => option.value === sortFilterStore.season,
+          )?.label ?? "",
+        value: sortFilterStore.season,
+      },
+    ];
+    const activeFilterChips = activeFilterCandidates.filter(
+      (chip) => chip.value && chip.label,
+    );
+    const advancedFilterGroups = [
+      {
+        key: "voice" as const,
+        label: langText(lang, "Voice", "Озвучка"),
+        options: voiceOptions,
+        value: sortFilterStore.voice,
+      },
+      {
+        key: "category" as const,
+        label: langText(lang, "Category", "Категория"),
+        options: categoryOptions,
+        value: sortFilterStore.category,
+      },
+      {
+        key: "season" as const,
+        label: langText(lang, "Season", "Сезон"),
+        options: seasonOptions,
+        value: sortFilterStore.season,
+      },
+    ].filter((group) => group.options.length > 0);
 
     return (
       <>
@@ -210,28 +467,148 @@ export const TorrentList = component$(
         )}
 
         {sortedTorrents.value !== null && (
-          <form
-            onReset$={resetFilters}
-            class="mb-4 flex flex-wrap items-center gap-2"
-          >
-            {filterOptions.map(({ key, label }) => (
+          <form onReset$={resetFilters} class="relative z-20 mb-4 space-y-3">
+            <div class="flex flex-wrap items-end gap-3">
+              {(qualityOptions.length > 0 || dynamicRangeOptions.length > 0) && (
+                <details
+                  class="dropdown dropdown-bottom"
+                  ref={formatDropdownRef}
+                >
+                  <summary class="btn btn-outline btn-sm min-w-36 justify-between">
+                    {formatLabelParts.length > 0
+                      ? `${langText(lang, "Format", "Формат")}: ${formatLabelParts.join(" + ")}`
+                      : langText(lang, "Format", "Формат")}
+                  </summary>
+                  <div class="dropdown-content card card-border border-base-300 bg-base-100 z-20 mt-2 w-72 shadow-lg">
+                    <div class="card-body gap-3 p-4">
+                      {qualityOptions.length > 0 && (
+                        <label class="form-control">
+                          <div class="label px-0 pt-0 pb-1">
+                            <span class="label-text text-xs font-medium">
+                              {langText(lang, "Resolution", "Разрешение")}
+                            </span>
+                          </div>
+                          <select
+                            class="select select-bordered select-sm w-full"
+                            value={sortFilterStore.quality}
+                            onChange$={(_, element) => {
+                              setSelectFilter("quality", element.value);
+                            }}
+                          >
+                            <option value="">
+                              {langText(lang, "Any", "Любой")}
+                            </option>
+                            {qualityOptions.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {`${option.label} (${option.count})`}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+
+                      {dynamicRangeOptions.length > 0 && (
+                        <label class="form-control">
+                          <div class="label px-0 pt-0 pb-1">
+                            <span class="label-text text-xs font-medium">
+                              {langText(
+                                lang,
+                                "Dynamic range",
+                                "Динамический диапазон",
+                              )}
+                            </span>
+                          </div>
+                          <select
+                            class="select select-bordered select-sm w-full"
+                            value={sortFilterStore.dynamicRange}
+                            onChange$={(_, element) => {
+                              setSelectFilter("dynamicRange", element.value);
+                            }}
+                          >
+                            <option value="">
+                              {langText(lang, "Any", "Любой")}
+                            </option>
+                            {dynamicRangeOptions.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {`${option.label} (${option.count})`}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                    </div>
+                  </div>
+                </details>
+              )}
+
+              {trackerOptions.length > 0 && (
+                <label class="form-control min-w-52">
+                  <div class="label px-0 pt-0 pb-1">
+                    <span class="label-text text-xs font-medium">
+                      {langText(lang, "Tracker", "Трекер")}
+                    </span>
+                  </div>
+                  <select
+                    class="select select-bordered select-sm w-full"
+                    value={sortFilterStore.tracker}
+                    onChange$={(_, element) => {
+                      setSelectFilter("tracker", element.value);
+                    }}
+                  >
+                    <option value="">{langText(lang, "Any", "Любой")}</option>
+                    {trackerOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {`${option.label} (${option.count})`}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
               <input
-                key={key}
-                class="btn btn-sm"
-                type="checkbox"
-                checked={sortFilterStore[key]}
-                aria-label={label}
-                onChange$={(_, element) => {
-                  setFilter(key, element.checked);
-                }}
+                class="btn btn-ghost btn-sm"
+                type="reset"
+                value={langText(lang, "Reset", "Сброс")}
+                aria-label={resetFiltersLabel}
               />
-            ))}
-            <input
-              class="btn btn-square btn-sm"
-              type="reset"
-              value="×"
-              aria-label={resetFiltersLabel}
-            />
+            </div>
+
+            {advancedFilterGroups.length > 0 && (
+              <details class="collapse-arrow border-base-300 bg-base-100 collapse border">
+                <summary class="collapse-title min-h-0 py-3 text-sm font-medium">
+                  {langText(lang, "Advanced filters", "Расширенные фильтры")}
+                </summary>
+                <div class="collapse-content">
+                  <div class="grid gap-2 pt-1 sm:grid-cols-2 lg:grid-cols-3">
+                    {advancedFilterGroups.map(({ key, label, options, value }) => (
+                      <label class="form-control" key={key}>
+                        <div class="label px-0 pt-0 pb-1">
+                          <span class="label-text text-xs font-medium">
+                            {label}
+                          </span>
+                        </div>
+                        <select
+                          class="select select-bordered select-sm w-full"
+                          value={value}
+                          onChange$={(_, element) => {
+                            setSelectFilter(key, element.value);
+                          }}
+                        >
+                          <option value="">
+                            {langText(lang, "Any", "Любой")}
+                          </option>
+                          {options.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {`${option.label} (${option.count})`}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </details>
+            )}
           </form>
         )}
 
@@ -244,9 +621,33 @@ export const TorrentList = component$(
               <div>{langNotFound(lang)}</div>
             )}
           {sortedTorrents.value !== null && sortedTorrents.value.length > 0 && (
-            <div>
-              {langFound(lang)} {sortedTorrents.value.length}{" "}
-              {langTorrentov(lang)}
+            <div class="flex flex-wrap items-center gap-2">
+              <span>
+                {langFound(lang)} {sortedTorrents.value.length}{" "}
+                {langTorrentov(lang)}
+              </span>
+              {sourceStats.total > 0 && (
+                <span class="badge badge-ghost">
+                  {langText(lang, "JacRed", "JacRed")}: {sourceStats.total}
+                  {sourceStats.loaded > 0 && ` / ${sourceStats.loaded}`}
+                </span>
+              )}
+              {activeFilterChips.map((chip) => (
+                <span
+                  class="badge badge-primary badge-soft gap-1 pr-1"
+                  key={`${chip.key}-${chip.value}`}
+                >
+                  {chip.label}
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-circle h-4 min-h-0 w-4 p-0 text-xs"
+                    aria-label={`${resetFiltersLabel}: ${chip.label}`}
+                    onClick$={() => clearSelectFilter(chip.key)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
             </div>
           )}
         </section>
@@ -256,6 +657,7 @@ export const TorrentList = component$(
             <TorrentBlock
               torrent={torrent}
               movie={movie}
+              lang={lang}
               key={torrent.Magnet}
             />
           ))}

--- a/src/components/torrent.tsx
+++ b/src/components/torrent.tsx
@@ -1,103 +1,193 @@
 import { $, component$, useContext } from "@builder.io/qwik";
+import {
+  BsBoxArrowUpRight,
+  BsMagnet,
+  BsPlusCircle,
+} from "@qwikest/icons/bootstrap";
 import { ToastManagerContext } from "qwik-toasts";
 import type { MediaDetails, Torrent } from "~/services/models";
 import { addTorrent } from "~/services/torrserver";
 import { readStorageString } from "~/utils/browser";
 import { formatRating } from "~/utils/format";
+import { langText } from "~/utils/languages";
+import {
+  getTorrentBadges,
+  type TorrentBadgeTone,
+} from "~/utils/torrent-format";
 
 interface TorrentListProps {
+  lang: string;
   torrent: Torrent;
   movie: MediaDetails;
 }
 
+const formatAvailability = (score?: number) =>
+  `${Math.round((score ?? 0) * 100)}%`;
+
+const getDisplayTitle = (torrent: Torrent) =>
+  [torrent.RussianName, torrent.OriginalName]
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .join(" / ") || torrent.Name;
+
+const getSecondaryTitle = (torrent: Torrent) => {
+  const displayTitle = getDisplayTitle(torrent);
+  return torrent.Name && torrent.Name !== displayTitle ? torrent.Name : "";
+};
+
+const getDateLabel = (torrent: Torrent) =>
+  (torrent.Date || torrent.UpdatedDate || "").slice(0, 10);
+
+const getBadgeClass = (tone: TorrentBadgeTone) => {
+  switch (tone) {
+    case "quality":
+      return "badge badge-primary badge-soft";
+    case "feature":
+      return "badge border-primary/40 bg-primary/10 text-primary font-medium";
+    case "video":
+      return "badge badge-neutral badge-soft uppercase";
+    case "tracker":
+      return "badge badge-ghost border-base-300 text-base-content/70";
+  }
+};
+
 export const TorrentBlock = component$(
-  ({ torrent, movie }: TorrentListProps) => {
+  ({ torrent, movie, lang }: TorrentListProps) => {
     const toastManager = useContext(ToastManagerContext);
+    const displayTitle = getDisplayTitle(torrent);
+    const secondaryTitle = getSecondaryTitle(torrent);
+    const dateLabel = getDateLabel(torrent);
+    const categoryBadges = (torrent.CategoryLabels?.length
+      ? torrent.CategoryLabels
+      : torrent.Categories
+    )?.slice(0, 3);
+    const voiceBadges = torrent.Voices?.slice(0, 3);
+    const seasonBadges = torrent.Seasons?.slice(0, 3);
+    const torrentBadges = getTorrentBadges(torrent);
 
     return (
-      <div class="card card-border border-base-300 bg-base-100 my-2 shadow-sm">
-        <div class="card-body">
-          <div class="flex flex-wrap items-center justify-between">
-            <div class="mb-2 text-start font-bold text-nowrap">
-              {torrent.K4 ? (
-                <span class="badge badge-info badge-soft mr-2">4K</span>
-              ) : (
-                <span class="badge badge-info badge-soft mr-2">FHD</span>
-              )}
-              {torrent.DV && (
-                <span class="badge badge-info badge-soft mr-2">
-                  Dolby Vision
-                </span>
-              )}
-              {torrent.HDR && !torrent.HDR10 && !torrent.HDR10plus && (
-                <span class="badge badge-info badge-soft mr-2">HDR</span>
-              )}
-              {torrent.HDR10 && !torrent.HDR10plus && (
-                <span class="badge badge-info badge-soft mr-2">HDR10</span>
-              )}
-              {torrent.HDR10plus && (
-                <span class="badge badge-info badge-soft mr-2">HDR10+</span>
-              )}
-            </div>
-
-            <div class="flex flex-wrap items-center text-nowrap">
-              <span class="badge badge-primary badge-soft mr-2">
-                {formatRating(torrent.Size)} Gb
-              </span>
-
-              <span class="badge badge-success badge-soft mr-1 rounded">
-                {torrent.Seeds}
-              </span>
-
-              <span class="badge badge-error badge-soft mr-6 rounded">
-                {torrent.Leeches}
-              </span>
-              <div class="my-2 flex space-x-1">
-                <a href={torrent.Magnet} target="_blank" rel="noreferrer">
-                  <button type="button" class="btn btn-accent btn-sm btn-soft">
-                    Open
-                  </button>
-                </a>
-                <button
-                  type="button"
-                  class="btn btn-accent btn-sm btn-soft"
-                  onClick$={$(async () => {
-                    const torrserv =
-                      readStorageString("selectedTorServer", "") || "";
-                    if (torrserv === "") {
-                      toastManager.addToast({
-                        message: "TorrServer hasn't been added!",
-                        type: "error",
-                        autocloseTime: 5000,
-                      });
-                      return;
-                    }
-                    try {
-                      await addTorrent(torrserv, torrent, movie);
-                      toastManager.addToast({
-                        message: "Torrent added!",
-                        type: "success",
-                        autocloseTime: 5000,
-                      });
-                    } catch (error) {
-                      console.error(error);
-                      toastManager.addToast({
-                        message: "Torrent hasn't been added!",
-                        type: "error",
-                        autocloseTime: 5000,
-                      });
-                    }
-                  })}
-                >
-                  Add to TorrServer
-                </button>
+      <div class="card card-border border-base-300 bg-base-100 my-3 shadow-sm">
+        <div class="card-body gap-4">
+          <div class="flex flex-col gap-4">
+            <div class="min-w-0 flex-1 text-start">
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                {torrentBadges.map((badge) => (
+                  <span class={getBadgeClass(badge.tone)} key={badge.label}>
+                    {badge.label}
+                  </span>
+                ))}
               </div>
+
+              <h4 class="text-base font-semibold leading-snug break-words">
+                {displayTitle}
+              </h4>
+              {secondaryTitle && (
+                <p class="text-base-content/65 mt-1 line-clamp-2 text-sm leading-relaxed">
+                  {secondaryTitle}
+                </p>
+              )}
             </div>
           </div>
 
-          <div class="text-start">
-            <div>{torrent.Name}</div>
-            <div class="text-sm font-light">{torrent.Date.slice(0, 10)}</div>
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="badge badge-primary badge-soft">
+              {torrent.SizeName || `${formatRating(torrent.Size)} GB`}
+            </span>
+
+            <span class="badge badge-success badge-soft rounded">
+              {torrent.Seeds} {langText(lang, "seeds", "сидов")}
+            </span>
+
+            <span class="badge badge-error badge-soft rounded">
+              {torrent.Peers ?? torrent.Leeches} {langText(lang, "peers", "пиров")}
+            </span>
+
+            {torrent.AvailabilityScore !== undefined && (
+              <span class="badge badge-warning badge-soft rounded">
+                {formatAvailability(torrent.AvailabilityScore)}{" "}
+                {langText(lang, "availability", "доступность")}
+              </span>
+            )}
+
+            {dateLabel && (
+              <span class="badge badge-ghost rounded">{dateLabel}</span>
+            )}
+          </div>
+
+          {(categoryBadges?.length || voiceBadges?.length || seasonBadges?.length) && (
+            <div class="flex flex-wrap items-center gap-2">
+              {categoryBadges?.map((category) => (
+                <span class="badge badge-ghost border-base-300" key={`category-${category}`}>
+                  {category}
+                </span>
+              ))}
+              {voiceBadges?.map((voice) => (
+                <span class="badge badge-ghost border-base-300" key={`voice-${voice}`}>
+                  {voice}
+                </span>
+              ))}
+              {seasonBadges?.map((season) => (
+                <span class="badge badge-ghost border-base-300" key={`season-${season}`}>
+                  S{season}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div class="flex flex-wrap items-center gap-2">
+            <a
+              href={torrent.Magnet}
+              target="_blank"
+              rel="noreferrer"
+              class="btn btn-outline btn-sm"
+            >
+              <BsMagnet class="h-4 w-4" />
+              Magnet
+            </a>
+            {torrent.DetailsUrl && (
+              <a
+                href={torrent.DetailsUrl}
+                target="_blank"
+                rel="noreferrer"
+                class="btn btn-outline btn-sm"
+              >
+                <BsBoxArrowUpRight class="h-4 w-4" />
+                {langText(lang, "Source", "Источник")}
+              </a>
+            )}
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              onClick$={$(async () => {
+                const torrserv =
+                  readStorageString("selectedTorServer", "") || "";
+                if (torrserv === "") {
+                  toastManager.addToast({
+                    message: "TorrServer hasn't been added!",
+                    type: "error",
+                    autocloseTime: 5000,
+                  });
+                  return;
+                }
+                try {
+                  await addTorrent(torrserv, torrent, movie);
+                  toastManager.addToast({
+                    message: "Torrent added!",
+                    type: "success",
+                    autocloseTime: 5000,
+                  });
+                } catch (error) {
+                  console.error(error);
+                  toastManager.addToast({
+                    message: "Torrent hasn't been added!",
+                    type: "error",
+                    autocloseTime: 5000,
+                  });
+                }
+              })}
+            >
+              <BsPlusCircle class="h-4 w-4" />
+              TorrServer
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/torrents-list-modal.tsx
+++ b/src/components/torrents-list-modal.tsx
@@ -2,8 +2,11 @@ import { $, component$, useStore } from "@builder.io/qwik";
 import { server$ } from "@builder.io/qwik-city";
 import { HiChevronDownSolid } from "@qwikest/icons/heroicons";
 import { TorrentList } from "~/components/torrent-list";
-import { getTorrents } from "~/services/cloud-func-api";
 import type { MediaDetails, Season, Torrent } from "~/services/models";
+import {
+  getTorrentSearch,
+  type getTorrentsType,
+} from "~/services/torrent-search";
 import { useQueryParamsLoader } from "~/routes/(auth-guard)/layout";
 import { showDialogById } from "~/utils/browser";
 import { formatYear } from "~/utils/format";
@@ -22,19 +25,33 @@ export const TorrentsModal = component$(
   ({ title, year, isMovie, seasons, media, lang }: TorModalPros) => {
     const resource = useQueryParamsLoader();
     const torrentsStore = useStore({
+      loaded: 0,
+      season: undefined as number | undefined,
+      total: 0,
       torrents: null as Torrent[] | null,
       year,
     });
     const getTorrentsToggle = $(
-      async (name: string, year: number, isMovie: boolean) => {
+      async (
+        name: string,
+        year: number,
+        isMovie: boolean,
+        season?: number,
+      ) => {
         torrentsStore.torrents = null;
+        torrentsStore.season = season;
+        torrentsStore.loaded = 0;
+        torrentsStore.total = 0;
         torrentsStore.year = year;
         const torrModal = showDialogById("torrentsModal");
         if (torrModal) {
           try {
-            torrentsStore.torrents = await server$(() => {
-              return getTorrents({ name: name, year: year, isMovie: isMovie });
-            })();
+            const result = await server$((request: getTorrentsType) =>
+              getTorrentSearch(request),
+            )({ isMovie, name, season, year });
+            torrentsStore.loaded = result.loaded;
+            torrentsStore.total = result.total;
+            torrentsStore.torrents = result.torrents;
           } catch (error) {
             torrentsStore.torrents = [];
             console.error(error);
@@ -73,7 +90,12 @@ export const TorrentsModal = component$(
                       class="text-left"
                       onClick$={() => {
                         const updatedYear = formatYear(s.air_date);
-                        getTorrentsToggle(title, updatedYear, isMovie);
+                        getTorrentsToggle(
+                          title,
+                          updatedYear,
+                          isMovie,
+                          s.season_number,
+                        );
                       }}
                     >
                       {langSeason(lang)}
@@ -109,6 +131,9 @@ export const TorrentsModal = component$(
                 isMovie={isMovie}
                 movie={media}
                 lang={lang}
+                season={torrentsStore.season}
+                sourceLoaded={torrentsStore.loaded}
+                sourceTotal={torrentsStore.total}
               />
             </div>
           </div>

--- a/src/services/cloud-func-api.ts
+++ b/src/services/cloud-func-api.ts
@@ -1,4 +1,4 @@
-import type { ImdbRating, Torrent } from "./models";
+import type { ImdbRating } from "./models";
 import { createJsonApiClient, getOptionalResult } from "./json-api";
 
 const baseCGURL = "https://moviestracker-gw-eu-w1-8vmmbwbl.ew.gateway.dev";
@@ -31,19 +31,4 @@ export const getOptionalImdbRating = async (imdb_id?: null | string) => {
 			console.error(`Unable to fetch IMDb rating for ${imdb_id}`, error);
 		},
 	);
-};
-
-export type getTorrentsType = {
-	name: string;
-	year: number;
-	isMovie: boolean;
-};
-export const getTorrents = ({ name, year, isMovie }: getTorrentsType) => {
-	return cloudApiClient.request<Torrent[]>("gettorrents", {
-		search: {
-			MovieName: name,
-			Year: year,
-			isMovie,
-		},
-	});
 };

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -488,6 +488,18 @@ export type Torrent = {
 	Seeds: number;
 	Leeches: number;
 	Hash: string;
+	AvailabilityScore?: number;
+	Categories?: string[];
+	CategoryLabels?: string[];
+	Peers?: number;
+	Quality?: number;
+	QualityLabel?: string;
+	Seasons?: number[];
+	SizeName?: string;
+	Tracker?: string;
+	UpdatedDate?: string;
+	VideoType?: string;
+	Voices?: string[];
 };
 
 export type ImdbRating = {

--- a/src/services/torrent-search.test.ts
+++ b/src/services/torrent-search.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+	clearTorrentSearchCacheForTests,
+	getTorrentSearch,
+	getTorrents,
+	normalizeJacRedResults,
+} from "./torrent-search";
+
+const originalConsoleError = console.error;
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+	JACRED_API_BASE_URL: process.env.JACRED_API_BASE_URL,
+	JACRED_SEARCH_LIMIT: process.env.JACRED_SEARCH_LIMIT,
+	JACRED_SEARCH_PATH: process.env.JACRED_SEARCH_PATH,
+	JACRED_SEARCH_TIMEOUT_MS: process.env.JACRED_SEARCH_TIMEOUT_MS,
+};
+
+const createJsonResponse = (body: unknown, status = 200) =>
+	({
+		json: async () => body,
+		ok: status >= 200 && status < 300,
+		status,
+	}) as Response;
+
+const restoreEnv = () => {
+	for (const [key, value] of Object.entries(originalEnv)) {
+		if (value === undefined) {
+			delete process.env[key as keyof typeof originalEnv];
+		} else {
+			process.env[key as keyof typeof originalEnv] = value;
+		}
+	}
+};
+
+afterEach(() => {
+	clearTorrentSearchCacheForTests();
+	console.error = originalConsoleError;
+	globalThis.fetch = originalFetch;
+	restoreEnv();
+});
+
+describe("JacRed torrent search service", () => {
+	it("normalizes JacRed results into the legacy Torrent shape", () => {
+		const [torrent] = normalizeJacRedResults(
+			[
+				{
+					created_at: "2026-06-03",
+					id: "jacred-id",
+					magnet:
+						"magnet:?xt=urn:btih:61065ea115b7cc3e8db9fb5ab1f6f327f08bd1c9",
+					name: "Матрица",
+					original_name: "The Matrix",
+					peers: 27,
+					quality: 2160,
+					quality_label: "4K",
+					seeders: 449,
+					size_name: "2.00 GB",
+					size: 2 * 1024 * 1024 * 1024,
+					source_url: "https://rutracker.org/forum/viewtopic.php?t=6306464",
+					title:
+						"Матрица / The Matrix [1999, WEB-DL 2160p, HDR10+, Dolby Vision]",
+					tracker: "rutracker",
+					video_type: "hdr",
+					voices: ["Дубляж"],
+					year: 1999,
+				},
+			],
+			{ isMovie: true, name: "The Matrix", year: 1999 },
+		);
+
+		expect(torrent).toEqual({
+			AvailabilityScore: 0,
+			Categories: [],
+			CategoryLabels: [],
+			Date: "2026-06-03",
+			DetailsUrl: "https://rutracker.org/forum/viewtopic.php?t=6306464",
+			DV: true,
+			FHD: false,
+			HDR: true,
+			HDR10: false,
+			HDR10plus: true,
+			Hash: "61065EA115B7CC3E8DB9FB5AB1F6F327F08BD1C9",
+			K4: true,
+			Leeches: 27,
+			Magnet:
+				"magnet:?xt=urn:btih:61065ea115b7cc3e8db9fb5ab1f6f327f08bd1c9",
+			Name: "Матрица / The Matrix [1999, WEB-DL 2160p, HDR10+, Dolby Vision]",
+			OriginalName: "The Matrix",
+			Peers: 27,
+			Quality: 2160,
+			QualityLabel: "4K",
+			RussianName: "Матрица",
+			Seeds: 449,
+			Seasons: [],
+			Size: 2,
+			SizeName: "2.00 GB",
+			Tracker: "rutracker",
+			UpdatedDate: undefined,
+			VideoType: "hdr",
+			Voices: ["Дубляж"],
+			Year: "1999",
+		});
+	});
+
+	it("drops missing magnets and de-duplicates by BTIH hash", () => {
+		const torrents = normalizeJacRedResults(
+			[
+				{ id: "missing", title: "No magnet" },
+				{
+					magnet: "magnet:?xt=urn:btih:ABC123",
+					quality: 1080,
+					title: "First",
+				},
+				{
+					magnet: "magnet:?xt=urn:btih:abc123&tr=http://tracker",
+					quality: 1080,
+					title: "Duplicate",
+				},
+			],
+			{ isMovie: false, name: "Show", year: 2024 },
+		);
+
+		expect(torrents).toHaveLength(1);
+		expect(torrents[0].Name).toBe("First");
+		expect(torrents[0].FHD).toBe(true);
+	});
+
+	it("sends movie category and clamps JacRed limit", async () => {
+		process.env.JACRED_API_BASE_URL = "https://jacred.example";
+		process.env.JACRED_SEARCH_LIMIT = "200";
+
+		const fetchMock = mock(async () =>
+			createJsonResponse({
+				limit: 120,
+				loaded: 0,
+				open: true,
+				query: "Matrix",
+				results: [],
+				total: 0,
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		await getTorrents({
+			isMovie: true,
+			limit: 500,
+			name: " Matrix ",
+			year: 1999,
+		});
+
+		const firstCall = fetchMock.mock.calls[0] as unknown[] | undefined;
+		if (!firstCall) {
+			throw new Error("Expected JacRed fetch to be called");
+		}
+
+		const requestUrl = String(firstCall[0]);
+		const url = new URL(requestUrl);
+		expect(`${url.origin}${url.pathname}`).toBe(
+			"https://jacred.example/api/search",
+		);
+		expect(url.searchParams.get("query")).toBe("Matrix");
+		expect(url.searchParams.get("year")).toBe("1999");
+		expect(url.searchParams.get("category")).toBe("movie");
+		expect(url.searchParams.get("sort")).toBe("sid");
+		expect(url.searchParams.get("limit")).toBe("120");
+	});
+
+	it("sends TV season without forcing a category", async () => {
+		process.env.JACRED_API_BASE_URL = "https://jacred.example";
+
+		const fetchMock = mock(async () =>
+			createJsonResponse({
+				limit: 80,
+				loaded: 0,
+				open: true,
+				query: "Castlevania",
+				results: [],
+				total: 0,
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		await getTorrents({
+			isMovie: false,
+			name: "Castlevania",
+			season: 2,
+			year: 2018,
+		});
+
+		const firstCall = fetchMock.mock.calls[0] as unknown[] | undefined;
+		if (!firstCall) {
+			throw new Error("Expected JacRed fetch to be called");
+		}
+
+		const url = new URL(String(firstCall[0]));
+		expect(url.searchParams.get("season")).toBe("2");
+		expect(url.searchParams.get("category")).toBeNull();
+	});
+
+	it("returns cached results for repeated equivalent requests", async () => {
+		const fetchMock = mock(async () =>
+			createJsonResponse({
+				limit: 80,
+				loaded: 1,
+				open: true,
+				query: "Matrix",
+				results: [
+					{
+						magnet: "magnet:?xt=urn:btih:CACHE123",
+						title: "Cached",
+					},
+				],
+				total: 1,
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const first = await getTorrents({
+			isMovie: true,
+			name: "Matrix",
+			year: 1999,
+		});
+		const second = await getTorrents({
+			isMovie: true,
+			name: " matrix ",
+			year: 1999,
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(second).toEqual(first);
+	});
+
+	it("returns JacRed source counts with normalized torrents", async () => {
+		const fetchMock = mock(async () =>
+			createJsonResponse({
+				limit: 80,
+				loaded: 80,
+				open: true,
+				query: "Matrix",
+				results: [
+					{
+						magnet: "magnet:?xt=urn:btih:SUMMARY123",
+						title: "Summary",
+					},
+				],
+				total: 197,
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await getTorrentSearch({
+			isMovie: true,
+			name: "Matrix",
+			year: 1999,
+		});
+
+		expect(result.total).toBe(197);
+		expect(result.loaded).toBe(80);
+		expect(result.torrents).toHaveLength(1);
+	});
+
+	it("returns an empty list for short queries without fetching", async () => {
+		const fetchMock = mock(async () => createJsonResponse({ results: [] }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await getTorrents({ isMovie: true, name: "m", year: 1999 });
+
+		expect(result).toEqual([]);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("fails closed for JacRed proof-of-work and rate-limit responses", async () => {
+		const consoleErrorMock = mock(() => undefined);
+		const fetchMock = mock(async () => createJsonResponse({}, 428));
+		console.error = consoleErrorMock;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await getTorrents({
+			isMovie: true,
+			name: "Matrix",
+			year: 1999,
+		});
+
+		expect(result).toEqual([]);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries transient JacRed failures once", async () => {
+		const consoleErrorMock = mock(() => undefined);
+		const fetchMock = mock(async () => createJsonResponse({}, 503));
+		console.error = consoleErrorMock;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await getTorrents({
+			isMovie: true,
+			name: "Matrix",
+			year: 1999,
+		});
+
+		expect(result).toEqual([]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries network failures once", async () => {
+		const consoleErrorMock = mock(() => undefined);
+		const fetchMock = mock(async () => {
+			throw new Error("socket closed");
+		});
+		console.error = consoleErrorMock;
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await getTorrents({
+			isMovie: true,
+			name: "Matrix",
+			year: 1999,
+		});
+
+		expect(result).toEqual([]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/services/torrent-search.ts
+++ b/src/services/torrent-search.ts
@@ -1,0 +1,454 @@
+import type { Torrent } from "./models";
+
+const DEFAULT_JACRED_API_BASE_URL = "https://api.jacred.su";
+const DEFAULT_JACRED_SEARCH_PATH = "/api/search";
+const DEFAULT_JACRED_SEARCH_LIMIT = 80;
+const DEFAULT_JACRED_SEARCH_TIMEOUT_MS = 7000;
+const JACRED_SEARCH_LIMIT_MAX = 120;
+const JACRED_CACHE_TTL_MS = 90_000;
+const JACRED_CACHE_MAX_ENTRIES = 200;
+const JACRED_RETRY_STATUSES = new Set([502, 503, 504]);
+
+export type TorrentSearchRequest = {
+	name: string;
+	year: number;
+	isMovie: boolean;
+	season?: number;
+	limit?: number;
+};
+
+export type getTorrentsType = TorrentSearchRequest;
+
+export type TorrentSearchResult = {
+	facets?: JacRedFacets;
+	limit: number;
+	loaded: number;
+	torrents: Torrent[];
+	total: number;
+};
+
+export type JacRedFacet = {
+	count: number;
+	label?: string;
+	value: number | string;
+};
+
+export type JacRedFacets = {
+	categories?: JacRedFacet[];
+	qualities?: JacRedFacet[];
+	seasons?: JacRedFacet[];
+	trackers?: JacRedFacet[];
+	video_types?: JacRedFacet[];
+	voices?: JacRedFacet[];
+	years?: JacRedFacet[];
+};
+
+export type JacRedSearchResponse = {
+	facets?: JacRedFacets;
+	limit: number;
+	loaded: number;
+	open: boolean;
+	query: string;
+	results: JacRedResult[];
+	total: number;
+};
+
+export type JacRedResult = {
+	availability_score?: number;
+	categories?: string[];
+	category_labels?: string[];
+	created_at?: string;
+	id?: string;
+	magnet?: string;
+	magnet_available?: boolean;
+	name?: string;
+	original_name?: string;
+	peers?: number;
+	quality?: number;
+	quality_label?: string;
+	seasons?: number[];
+	seeders?: number;
+	size?: number;
+	size_name?: string;
+	source_url?: string;
+	title?: string;
+	tracker?: string;
+	updated_at?: string;
+	video_type?: string;
+	voices?: string[];
+	year?: number;
+};
+
+type CacheEntry = {
+	expiresAt: number;
+	value: TorrentSearchResult;
+};
+
+export class JacRedSearchError extends Error {
+	constructor(
+		message: string,
+		readonly status?: number,
+		readonly retryable = false,
+	) {
+		super(message);
+		this.name = "JacRedSearchError";
+	}
+}
+
+const torrentCache = new Map<string, CacheEntry>();
+
+const clampInteger = (value: number, fallback: number, max: number) => {
+	if (!Number.isFinite(value) || value < 1) {
+		return fallback;
+	}
+
+	return Math.min(Math.trunc(value), max);
+};
+
+const readIntegerEnv = (key: string, fallback: number, max: number) => {
+	const raw = process.env[key];
+	if (!raw) {
+		return fallback;
+	}
+
+	return clampInteger(Number.parseInt(raw, 10), fallback, max);
+};
+
+const getJacRedConfig = () => ({
+	baseUrl: process.env.JACRED_API_BASE_URL || DEFAULT_JACRED_API_BASE_URL,
+	limit: readIntegerEnv(
+		"JACRED_SEARCH_LIMIT",
+		DEFAULT_JACRED_SEARCH_LIMIT,
+		JACRED_SEARCH_LIMIT_MAX,
+	),
+	path: process.env.JACRED_SEARCH_PATH || DEFAULT_JACRED_SEARCH_PATH,
+	timeout: readIntegerEnv(
+		"JACRED_SEARCH_TIMEOUT_MS",
+		DEFAULT_JACRED_SEARCH_TIMEOUT_MS,
+		60_000,
+	),
+});
+
+const isPositiveInteger = (value: number | undefined): value is number =>
+	typeof value === "number" && Number.isInteger(value) && value > 0;
+
+const getRequestLimit = (request: TorrentSearchRequest) => {
+	const config = getJacRedConfig();
+	return clampInteger(
+		request.limit ?? config.limit,
+		config.limit,
+		JACRED_SEARCH_LIMIT_MAX,
+	);
+};
+
+const normalizeSearchRequest = (request: TorrentSearchRequest) => ({
+	isMovie: request.isMovie,
+	limit: getRequestLimit(request),
+	name: request.name.trim(),
+	season: isPositiveInteger(request.season) ? request.season : undefined,
+	year: isPositiveInteger(request.year) ? request.year : undefined,
+});
+
+const buildCacheKey = (request: TorrentSearchRequest) => {
+	const normalized = normalizeSearchRequest(request);
+	return JSON.stringify({
+		category: normalized.isMovie ? "movie" : "",
+		limit: normalized.limit,
+		name: normalized.name.toLocaleLowerCase(),
+		season: normalized.season ?? null,
+		year: normalized.year ?? null,
+	});
+};
+
+export const buildJacRedSearchUrl = (request: TorrentSearchRequest) => {
+	const config = getJacRedConfig();
+	const normalizedBaseUrl = config.baseUrl.endsWith("/")
+		? config.baseUrl
+		: `${config.baseUrl}/`;
+	const normalizedPath = config.path.replace(/^\/+/, "");
+	const url = new URL(normalizedPath, normalizedBaseUrl);
+	const normalized = normalizeSearchRequest(request);
+
+	url.searchParams.set("query", normalized.name);
+	url.searchParams.set("sort", "sid");
+	url.searchParams.set("limit", String(normalized.limit));
+
+	if (normalized.year) {
+		url.searchParams.set("year", String(normalized.year));
+	}
+
+	if (normalized.isMovie) {
+		url.searchParams.set("category", "movie");
+	}
+
+	if (normalized.season) {
+		url.searchParams.set("season", String(normalized.season));
+	}
+
+	return url;
+};
+
+const getCachedTorrents = (cacheKey: string) => {
+	const entry = torrentCache.get(cacheKey);
+	if (!entry) {
+		return null;
+	}
+
+	if (entry.expiresAt <= Date.now()) {
+		torrentCache.delete(cacheKey);
+		return null;
+	}
+
+	return entry.value;
+};
+
+const setCachedTorrents = (cacheKey: string, value: TorrentSearchResult) => {
+	torrentCache.set(cacheKey, {
+		expiresAt: Date.now() + JACRED_CACHE_TTL_MS,
+		value,
+	});
+
+	if (torrentCache.size <= JACRED_CACHE_MAX_ENTRIES) {
+		return;
+	}
+
+	const [oldestKey] = torrentCache.keys();
+	if (oldestKey) {
+		torrentCache.delete(oldestKey);
+	}
+};
+
+const fetchWithTimeout = async (
+	resource: string,
+	timeout: number,
+): Promise<Response> => {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeout);
+
+	try {
+		return await fetch(resource, {
+			headers: {
+				"X-JacRed-Client": "moviestracker",
+			},
+			signal: controller.signal,
+		});
+	} catch (error) {
+		if (error instanceof Error && error.name === "AbortError") {
+			throw new JacRedSearchError(
+				`JacRed search timed out after ${timeout}ms`,
+				undefined,
+				true,
+			);
+		}
+
+		throw new JacRedSearchError("JacRed search network failure", undefined, true);
+	} finally {
+		clearTimeout(timer);
+	}
+};
+
+const delay = (ms: number) =>
+	new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+
+const requestJacRedSearch = async (
+	request: TorrentSearchRequest,
+): Promise<JacRedSearchResponse> => {
+	const config = getJacRedConfig();
+	const url = buildJacRedSearchUrl(request);
+	let lastError: unknown = null;
+
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			const response = await fetchWithTimeout(String(url), config.timeout);
+
+			if (!response.ok) {
+				const retryable = JACRED_RETRY_STATUSES.has(response.status);
+				throw new JacRedSearchError(
+					`JacRed search failed with status ${response.status}`,
+					response.status,
+					retryable,
+				);
+			}
+
+			const body = (await response.json()) as Partial<JacRedSearchResponse>;
+			if (!Array.isArray(body.results)) {
+				throw new JacRedSearchError("JacRed search returned an invalid body");
+			}
+
+			return {
+				facets: body.facets,
+				limit: Number(body.limit ?? 0),
+				loaded: Number(body.loaded ?? 0),
+				open: Boolean(body.open),
+				query: String(body.query ?? request.name),
+				results: body.results,
+				total: Number(body.total ?? body.results.length),
+			};
+		} catch (error) {
+			lastError = error;
+
+			const retryable =
+				error instanceof JacRedSearchError &&
+				error.retryable &&
+				error.status !== 428 &&
+				error.status !== 429;
+
+			if (!retryable || attempt > 0) {
+				break;
+			}
+
+			await delay(150 + Math.floor(Math.random() * 100));
+		}
+	}
+
+	throw lastError;
+};
+
+export const extractTorrentHash = (magnet: string) => {
+	const match = magnet.match(/xt=urn:btih:([^&]+)/i);
+	if (!match) {
+		return "";
+	}
+
+	try {
+		return decodeURIComponent(match[1]).toUpperCase();
+	} catch {
+		return match[1].toUpperCase();
+	}
+};
+
+const includesToken = (value: string, pattern: RegExp) => pattern.test(value);
+
+export const normalizeJacRedResults = (
+	results: JacRedResult[],
+	request: TorrentSearchRequest,
+): Torrent[] => {
+	const seen = new Set<string>();
+	const torrents: Torrent[] = [];
+
+	for (const result of results) {
+		const magnet = result.magnet?.trim();
+		if (!magnet) {
+			continue;
+		}
+
+		const title = result.title ?? result.name ?? "";
+		const normalizedTitle = title.toLocaleLowerCase();
+		const hash = extractTorrentHash(magnet) || result.id || "";
+		const dedupeKey = hash || magnet;
+		if (seen.has(dedupeKey)) {
+			continue;
+		}
+		seen.add(dedupeKey);
+
+		const quality = Number(result.quality ?? 0);
+		const videoType = (result.video_type ?? "").toLocaleLowerCase();
+		const isHdr =
+			videoType === "hdr" ||
+			includesToken(normalizedTitle, /\bhdr\b/i) ||
+			includesToken(normalizedTitle, /\bhdr10\b/i);
+		const isHdr10Plus = includesToken(title, /hdr10\+|hdr10plus/i);
+		const isHdr10 =
+			!isHdr10Plus && includesToken(title, /\bhdr10\b|hdr10/i);
+
+		torrents.push({
+			AvailabilityScore: Number(result.availability_score ?? 0),
+			Categories: result.categories ?? [],
+			CategoryLabels: result.category_labels ?? [],
+			Date: result.created_at ?? result.updated_at ?? "",
+			DetailsUrl: result.source_url ?? "",
+			DV: includesToken(title, /dolby\s*vision|\bdv\b/i),
+			FHD: quality === 1080,
+			HDR: isHdr,
+			HDR10: isHdr10,
+			HDR10plus: isHdr10Plus,
+			Hash: hash,
+			K4: quality === 2160,
+			Leeches: Number(result.peers ?? 0),
+			Magnet: magnet,
+			Name: title,
+			OriginalName: result.original_name ?? "",
+			Peers: Number(result.peers ?? 0),
+			Quality: quality || undefined,
+			QualityLabel: result.quality_label,
+			RussianName: result.name ?? "",
+			Seeds: Number(result.seeders ?? 0),
+			Seasons: result.seasons ?? [],
+			Size: Number(result.size ?? 0) / 1024 / 1024 / 1024,
+			SizeName: result.size_name,
+			Tracker: result.tracker,
+			UpdatedDate: result.updated_at,
+			VideoType: result.video_type,
+			Voices: result.voices ?? [],
+			Year: String(result.year ?? request.year),
+		});
+	}
+
+	return torrents;
+};
+
+const logJacRedSearchFailure = (
+	error: unknown,
+	request: TorrentSearchRequest,
+) => {
+	const status = error instanceof JacRedSearchError ? error.status : undefined;
+	console.error("JacRed torrent search failed", {
+		isMovie: request.isMovie,
+		nameLength: request.name.trim().length,
+		provider: "jacred",
+		season: request.season,
+		status,
+		year: request.year,
+	});
+};
+
+export const getTorrentSearch = async (
+	request: TorrentSearchRequest,
+): Promise<TorrentSearchResult> => {
+	if (request.name.trim().length < 2) {
+		return {
+			limit: getRequestLimit(request),
+			loaded: 0,
+			torrents: [],
+			total: 0,
+		};
+	}
+
+	const cacheKey = buildCacheKey(request);
+	const cached = getCachedTorrents(cacheKey);
+	if (cached) {
+		return cached;
+	}
+
+	try {
+		const response = await requestJacRedSearch(request);
+		const torrents = normalizeJacRedResults(response.results, request);
+		const result = {
+			facets: response.facets,
+			limit: response.limit,
+			loaded: response.loaded,
+			torrents,
+			total: response.total,
+		};
+		setCachedTorrents(cacheKey, result);
+		return result;
+	} catch (error) {
+		logJacRedSearchFailure(error, request);
+		return {
+			limit: getRequestLimit(request),
+			loaded: 0,
+			torrents: [],
+			total: 0,
+		};
+	}
+};
+
+export const getTorrents = async (
+	request: TorrentSearchRequest,
+): Promise<Torrent[]> => (await getTorrentSearch(request)).torrents;
+
+export const clearTorrentSearchCacheForTests = () => {
+	torrentCache.clear();
+};

--- a/src/utils/filter-utils.test.ts
+++ b/src/utils/filter-utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import type { Torrent } from "~/services/models";
+import { filterAndSortTorrents } from "~/utils/filter-utils";
+import { getTorrentBadges } from "~/utils/torrent-format";
+
+const createTorrent = (overrides: Partial<Torrent>): Torrent => ({
+  Date: "2026-01-01",
+  DetailsUrl: "",
+  DV: false,
+  FHD: false,
+  HDR: false,
+  HDR10: false,
+  HDR10plus: false,
+  Hash: overrides.Name ?? "hash",
+  K4: false,
+  Leeches: 0,
+  Magnet: `magnet:?xt=urn:btih:${overrides.Name ?? "hash"}`,
+  Name: "Torrent",
+  OriginalName: "",
+  RussianName: "",
+  Seeds: 0,
+  Size: 1,
+  Year: "2026",
+  ...overrides,
+});
+
+const createFilterState = (overrides = {}) => ({
+  category: "",
+  dynamicRange: "",
+  quality: "",
+  season: "",
+  selectedSort: "Date",
+  tracker: "",
+  videoType: "",
+  voice: "",
+  ...overrides,
+});
+
+describe("torrent filters", () => {
+  it("matches 4K by JacRed quality and legacy K4 fallback", () => {
+    const torrents = [
+      createTorrent({ Name: "jacred-4k", Quality: 2160 }),
+      createTorrent({ K4: true, Name: "legacy-4k" }),
+      createTorrent({ Name: "hd", Quality: 1080 }),
+    ];
+
+    const filtered = filterAndSortTorrents(
+      torrents,
+      createFilterState({ quality: "2160" }),
+    );
+
+    expect(filtered.map((torrent) => torrent.Name).sort()).toEqual([
+      "jacred-4k",
+      "legacy-4k",
+    ]);
+  });
+
+  it("filters by one strongest dynamic range value", () => {
+    const torrents = [
+      createTorrent({ DV: true, HDR: true, HDR10plus: true, Name: "dv" }),
+      createTorrent({ HDR: true, HDR10plus: true, Name: "hdr10plus" }),
+      createTorrent({ HDR: true, HDR10: true, Name: "hdr10" }),
+      createTorrent({ HDR: true, Name: "hdr" }),
+    ];
+
+    expect(
+      filterAndSortTorrents(
+        torrents,
+        createFilterState({ dynamicRange: "dv" }),
+      ).map((torrent) => torrent.Name),
+    ).toEqual(["dv"]);
+    expect(
+      filterAndSortTorrents(
+        torrents,
+        createFilterState({ dynamicRange: "hdr10plus" }),
+      ).map((torrent) => torrent.Name),
+    ).toEqual(["hdr10plus"]);
+    expect(
+      filterAndSortTorrents(
+        torrents,
+        createFilterState({ dynamicRange: "hdr10" }),
+      ).map((torrent) => torrent.Name),
+    ).toEqual(["hdr10"]);
+    expect(
+      filterAndSortTorrents(
+        torrents,
+        createFilterState({ dynamicRange: "hdr" }),
+      ).map((torrent) => torrent.Name),
+    ).toEqual(["hdr"]);
+  });
+
+  it("renders only one HDR-family badge per torrent card", () => {
+    const badges = getTorrentBadges(
+      createTorrent({
+        DV: true,
+        HDR: true,
+        HDR10: true,
+        HDR10plus: true,
+        QualityLabel: "4K",
+        Tracker: "rutracker",
+        VideoType: "hdr",
+      }),
+    );
+    const labels = badges.map((badge) => badge.label);
+
+    expect(labels).toEqual(["rutracker", "4K", "Dolby Vision"]);
+    expect(labels).not.toContain("HDR");
+    expect(labels).not.toContain("HDR10");
+    expect(labels).not.toContain("HDR10+");
+  });
+});

--- a/src/utils/filter-utils.ts
+++ b/src/utils/filter-utils.ts
@@ -1,12 +1,15 @@
 import type { Torrent } from "~/services/models";
+import { getTorrentDynamicRangeValue } from "~/utils/torrent-format";
 
 interface FilterState {
-  k4: boolean;
-  hdr: boolean;
-  hdr10: boolean;
-  hdr10plus: boolean;
-  dv: boolean;
+  category: string;
+  dynamicRange: string;
+  quality: string;
+  season: string;
   selectedSort: string;
+  tracker: string;
+  videoType: string;
+  voice: string;
 }
 
 export const filterAndSortTorrents = (
@@ -15,15 +18,44 @@ export const filterAndSortTorrents = (
 ): Torrent[] => {
   let filtered = [...torrents];
 
-  if (filterState.k4) filtered = filtered.filter((t) => t.K4);
-  if (filterState.hdr) filtered = filtered.filter((t) => t.HDR);
-  if (filterState.hdr10) filtered = filtered.filter((t) => t.HDR10);
-  if (filterState.hdr10plus) filtered = filtered.filter((t) => t.HDR10plus);
-  if (filterState.dv) filtered = filtered.filter((t) => t.DV);
+  if (filterState.tracker) {
+    filtered = filtered.filter((t) => t.Tracker === filterState.tracker);
+  }
+  if (filterState.quality) {
+    filtered = filtered.filter((t) => {
+      if (filterState.quality === "2160") {
+        return t.Quality === 2160 || t.K4;
+      }
+      if (filterState.quality === "1080") {
+        return t.Quality === 1080 || t.FHD;
+      }
+
+      return String(t.Quality ?? "") === filterState.quality;
+    });
+  }
+  if (filterState.dynamicRange) {
+    filtered = filtered.filter(
+      (t) => getTorrentDynamicRangeValue(t) === filterState.dynamicRange,
+    );
+  }
+  if (filterState.videoType) {
+    filtered = filtered.filter((t) => t.VideoType === filterState.videoType);
+  }
+  if (filterState.voice) {
+    filtered = filtered.filter((t) => t.Voices?.includes(filterState.voice));
+  }
+  if (filterState.category) {
+    filtered = filtered.filter((t) => t.Categories?.includes(filterState.category));
+  }
+  if (filterState.season) {
+    filtered = filtered.filter((t) =>
+      t.Seasons?.some((season) => String(season) === filterState.season),
+    );
+  }
 
   return filtered.sort((a, b) => {
-    const valA = a[filterState.selectedSort as keyof Torrent];
-    const valB = b[filterState.selectedSort as keyof Torrent];
+    const valA = a[filterState.selectedSort as keyof Torrent] ?? "";
+    const valB = b[filterState.selectedSort as keyof Torrent] ?? "";
 
     if (valA > valB) return -1;
     if (valA < valB) return 1;

--- a/src/utils/torrent-format.ts
+++ b/src/utils/torrent-format.ts
@@ -1,0 +1,94 @@
+import type { Torrent } from "~/services/models";
+
+export type DynamicRangeFilter = "" | "dv" | "hdr" | "hdr10" | "hdr10plus";
+export type TorrentBadgeTone = "feature" | "quality" | "tracker" | "video";
+
+export type TorrentBadge = {
+  label: string;
+  tone: TorrentBadgeTone;
+};
+
+const dynamicRangeLabels: Record<Exclude<DynamicRangeFilter, "">, string> = {
+  dv: "Dolby Vision",
+  hdr: "HDR",
+  hdr10: "HDR10",
+  hdr10plus: "HDR10+",
+};
+
+const hdrVideoTypes = new Set([
+  "dolby vision",
+  "dv",
+  "hdr",
+  "hdr10",
+  "hdr10+",
+  "hdr10plus",
+]);
+
+const addUniqueBadge = (
+  badges: TorrentBadge[],
+  seen: Set<string>,
+  label: string | undefined,
+  tone: TorrentBadgeTone,
+) => {
+  const normalized = label?.trim();
+  if (!normalized) {
+    return;
+  }
+
+  const key = normalized.toLocaleLowerCase();
+  if (seen.has(key)) {
+    return;
+  }
+
+  seen.add(key);
+  badges.push({ label: normalized, tone });
+};
+
+export const getDynamicRangeLabel = (value: DynamicRangeFilter) =>
+  value ? dynamicRangeLabels[value] : "";
+
+export const getTorrentDynamicRangeValue = (
+  torrent: Torrent,
+): DynamicRangeFilter => {
+  if (torrent.DV) {
+    return "dv";
+  }
+  if (torrent.HDR10plus) {
+    return "hdr10plus";
+  }
+  if (torrent.HDR10) {
+    return "hdr10";
+  }
+  if (torrent.HDR) {
+    return "hdr";
+  }
+
+  return "";
+};
+
+export const getTorrentBadges = (torrent: Torrent) => {
+  const badges: TorrentBadge[] = [];
+  const seen = new Set<string>();
+
+  addUniqueBadge(badges, seen, torrent.Tracker, "tracker");
+  addUniqueBadge(
+    badges,
+    seen,
+    torrent.QualityLabel || (torrent.K4 ? "4K" : torrent.FHD ? "FHD" : ""),
+    "quality",
+  );
+
+  addUniqueBadge(
+    badges,
+    seen,
+    getDynamicRangeLabel(getTorrentDynamicRangeValue(torrent)),
+    "feature",
+  );
+
+  const videoType = torrent.VideoType?.trim();
+  if (videoType && !hdrVideoTypes.has(videoType.toLocaleLowerCase())) {
+    addUniqueBadge(badges, seen, videoType.toUpperCase(), "video");
+  }
+
+  return badges;
+};


### PR DESCRIPTION
## Summary
- replace legacy torrent gateway search with server-side JacRed adapter
- add richer normalized torrent metadata and compact torrent filter UI
- remove duplicated 4K/HDR/DV filter controls and add Format dropdown with click-outside close

## Verification
- bun test src/utils/filter-utils.test.ts
- bun run build.types
- bun run lint
- bun run test
- bun run build