### PR TITLE
Fix Cloud Build Mongo SSG deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
-FROM oven/bun:1 AS deps
+ARG BUN_VERSION=1.3.11
+
+FROM oven/bun:${BUN_VERSION} AS deps
 WORKDIR /app
 COPY package.json bun.lockb ./
 RUN bun install --frozen-lockfile
 
-FROM oven/bun:1 AS build
+FROM oven/bun:${BUN_VERSION} AS build
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1 AS prod-deps
+FROM oven/bun:${BUN_VERSION} AS prod-deps
 WORKDIR /app
 COPY package.json bun.lockb ./
 RUN bun install --frozen-lockfile --production
 
-FROM oven/bun:distroless
+FROM oven/bun:${BUN_VERSION}-distroless
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/references/guardrails.md
+++ b/references/guardrails.md
@@ -57,6 +57,9 @@
 - Runtime auth must fail closed without a real `AUTH_SECRET`; do not allow a
   predictable placeholder secret in normal dev, preview, or deployed auth
   flows.
+- Keep MongoDB and Auth Mongo adapter runtime imports behind request-time
+  guards. Bun SSG may run without `MONGO_URI`, and MongoDB 7/BSON imports
+  Node APIs that can break Linux Cloud Build if loaded during SSG.
 - Production auth/origin handling must pin the public origin with `AUTH_URL`;
   add preview/custom hosts with `TRUSTED_ORIGINS` instead of trusting arbitrary
   `Host` or `x-forwarded-proto` headers.
@@ -89,6 +92,9 @@
 - `dist/**` and `server/**` are committed generated output.
 - The repo has a small Bun-based test surface, but coverage is still narrow.
 - `adapters/cloud-run/vite.config.ts` references a missing entry file.
+- Keep Docker's Bun image pinned to the same tested Bun version as CI. Floating
+  `oven/bun:1` can pick up Linux runtime regressions before GitHub CI sees
+  them.
 - Verify the usage of suspicious legacy files before deleting them.
 
 ## Claude Enforcement

--- a/src/routes/plugin@auth.ts
+++ b/src/routes/plugin@auth.ts
@@ -1,18 +1,18 @@
-import type { Adapter } from "@auth/core/adapters";
+import type { Adapter, AdapterUser } from "@auth/core/adapters";
 import type { Provider } from "@auth/core/providers";
 import type { GoogleProfile } from "@auth/core/providers/google";
+import type { Account, Profile, Session } from "@auth/core/types";
 import Google from "@auth/core/providers/google";
-import { MongoDBAdapter } from "@auth/mongodb-adapter";
 import { QwikAuth$ } from "@auth/qwik";
+import type { RequestEventCommon } from "@builder.io/qwik-city";
 import {
   resolveAuthTrustHost,
   resolveDatabaseAuthSecret,
   resolveFallbackJwtSecret,
 } from "./auth-config";
-import { mongoclient } from "../utils/mongodbinit";
 
 export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
-  ({ env }) => {
+  (async ({ env }: RequestEventCommon) => {
     const authSecret = env.get("AUTH_SECRET")?.trim();
     const lifecycleEvent = process.env.npm_lifecycle_event;
     const nodeEnv = env.get("NODE_ENV")?.trim() || process.env.NODE_ENV;
@@ -43,7 +43,32 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
           ]
         : [];
 
-    const mongo = mongoclient(env.get("MONGO_URI") ?? "");
+    const mongoUri = env.get("MONGO_URI") ?? "";
+    if (!mongoUri.startsWith("mongodb")) {
+      // During CI/SSG builds the runtime auth env may be intentionally absent.
+      // Keep the build-safe fallback self-contained so SSR generation can
+      // complete without runtime auth secrets.
+      return {
+        secret: resolveFallbackJwtSecret({
+          authSecret,
+          lifecycleEvent,
+          nodeEnv,
+        }),
+        trustHost,
+        session: {
+          strategy: "jwt",
+          maxAge: 60 * 60 * 24 * 7, // 1 week
+          updateAge: 60 * 60 * 24, // 1 day
+        },
+        providers,
+      };
+    }
+
+    const [{ MongoDBAdapter }, { mongoclient }] = await Promise.all([
+      import("@auth/mongodb-adapter"),
+      import("../utils/mongodbinit"),
+    ]);
+    const mongo = await mongoclient(mongoUri);
     if (!mongo) {
       // During CI/SSG builds the runtime auth env may be intentionally absent.
       // Keep the build-safe fallback self-contained so SSR generation can
@@ -77,7 +102,13 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
       trustHost,
       providers,
       callbacks: {
-        async session({ session, user }) {
+        async session({
+          session,
+          user,
+        }: {
+          session: Session;
+          user: AdapterUser;
+        }) {
           session.id = user.id;
           if (user.language) {
             session.language = user.language;
@@ -85,7 +116,13 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
 
           return session;
         },
-        async signIn({ account, profile }) {
+        async signIn({
+          account,
+          profile,
+        }: {
+          account: Account | null;
+          profile?: Profile;
+        }) {
           if (account && profile) {
             if (account.provider === "google") {
               const p = profile as GoogleProfile;
@@ -99,7 +136,7 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
         },
       },
     };
-  },
+  }) as unknown as Parameters<typeof QwikAuth$>[0],
 );
 
 declare module "@auth/core/types" {

--- a/src/utils/mongodbinit.ts
+++ b/src/utils/mongodbinit.ts
@@ -1,11 +1,11 @@
-import { MongoClient } from "mongodb";
+import type { MongoClient as MongoClientType } from "mongodb";
 
 type MongoGlobal = typeof globalThis & {
-	__moviesMongoClient?: MongoClient;
+	__moviesMongoClient?: MongoClientType;
 	__moviesMongoUri?: string;
 };
 
-export const mongoclient = (env: string) => {
+export const mongoclient = async (env: string) => {
 	if (!env.startsWith("mongodb")) {
 		return;
 	}
@@ -18,6 +18,7 @@ export const mongoclient = (env: string) => {
 		return globalMongo.__moviesMongoClient;
 	}
 
+	const { MongoClient } = await import("mongodb");
 	const client = new MongoClient(env, {
 		// Keep pool bounded to avoid Atlas connection spikes under load.
 		maxPoolSize: 20,


### PR DESCRIPTION
## Summary
- lazy-load MongoDB and the Auth Mongo adapter at request time so Bun SSG does not import MongoDB 7/BSON during Cloud Build
- pin the Docker Bun image used by Cloud Build
- document the deployment guardrails

## Verification
- bun run build.types
- bun run lint
- bun run build
- build-only Cloud Build in europe-west1: d4d75bf1-6304-482b-8e3e-4e7dd0ba32ad succeeded