### PR TITLE
refactor(torrserver): improve UI consistency and spacing

### DIFF
--- a/src/components/torrserver/torrserver-api-tools-modal.tsx
+++ b/src/components/torrserver/torrserver-api-tools-modal.tsx
@@ -50,7 +50,7 @@ const AddLinkSection = component$(
             </span>
             <input
               type="text"
-              class="input input-bordered min-h-11 w-full text-base"
+              class="input input-bordered w-full"
               placeholder={lt(
                 lang,
                 "magnet:?xt=... or http(s)://...",
@@ -68,7 +68,7 @@ const AddLinkSection = component$(
             </span>
             <input
               type="text"
-              class="input input-bordered min-h-11 w-full text-base"
+              class="input input-bordered w-full"
               placeholder={lt(
                 lang,
                 "Optional title",
@@ -86,7 +86,7 @@ const AddLinkSection = component$(
                 {lt(lang, "Category", "Категория")}
               </span>
               <select
-                class="select select-bordered min-h-11 w-full text-base"
+                class="select select-bordered w-full"
                 value={categoryValue.value}
                 onChange$={(_, el) => {
                   categoryValue.value = el.value;
@@ -114,7 +114,7 @@ const AddLinkSection = component$(
           </div>
           <button
             type="submit"
-            class="btn btn-primary min-h-11 w-full"
+            class="btn btn-primary w-full"
             disabled={!serverUrl || addLinkBusy}
           >
             {addLinkBusy
@@ -163,7 +163,7 @@ const UploadSection = component$(
           <input
             type="file"
             accept=".torrent"
-            class="file-input file-input-bordered min-h-11 w-full text-base"
+            class="file-input file-input-bordered w-full"
             onChange$={(_, element) => {
               onUploadFileChange$(element.files?.[0] ?? null);
             }}
@@ -180,7 +180,7 @@ const UploadSection = component$(
         </p>
         <button
           type="button"
-          class="btn btn-secondary min-h-11 w-full"
+          class="btn btn-secondary w-full"
           disabled={
             !serverUrl ||
             !uploadFileName ||
@@ -201,7 +201,7 @@ const UploadSection = component$(
             <span class="label label-text px-0 pb-1 text-xs">
               {lt(lang, "Download size in MB", "Размер скачивания в MB")}
             </span>
-            <span class="input input-bordered flex min-h-11 items-center gap-2 text-base">
+            <span class="input input-bordered flex items-center gap-2">
               <span class="text-base-content/70 text-xs">MB</span>
               <input
                 type="number"
@@ -219,7 +219,7 @@ const UploadSection = component$(
               href={downloadTestUrl}
               target="_blank"
               rel="noreferrer"
-              class="btn btn-outline min-h-11 w-full"
+              class="btn btn-outline w-full"
             >
               /download
             </a>
@@ -267,7 +267,7 @@ const SearchSection = component$(
           </span>
           <input
             type="text"
-            class="input input-bordered min-h-11 w-full text-base"
+            class="input input-bordered w-full"
             value={apiQuery.value}
             placeholder={lt(lang, "Search query", "Поисковый запрос")}
             onInput$={(_, element) => {
@@ -278,7 +278,7 @@ const SearchSection = component$(
         <div class="grid gap-2 sm:grid-cols-2">
           <button
             type="button"
-            class="btn btn-outline min-h-11"
+            class="btn btn-outline"
             disabled={!serverUrl || !apiQuery.value.trim()}
             onClick$={async () => {
               await onSearch$("rutor");
@@ -316,19 +316,19 @@ const SearchSection = component$(
           {searchResults.slice(0, 12).map((result, index) => (
             <div
               key={`${result.link || result.magnet || result.torrent || "result"}-${index}`}
-              class="rounded-box bg-base-100 border-base-300 border p-3"
+              class="rounded-box bg-base-100 border-base-200 border p-3"
             >
               <p class="truncate text-xs font-medium">
                 {result.name || result.link || result.magnet || result.torrent}
               </p>
-              <div class="mt-2 grid gap-2 sm:flex sm:items-center sm:justify-between">
-                <span class="text-base-content/60 text-[11px]">
+              <div class="mt-2 flex items-center justify-between gap-2">
+                <span class="text-base-content/60 text-xs">
                   {result.seed || result.seeders || result.peer || 0}{" "}
                   {lt(lang, "seeders", "сидеров")}
                 </span>
                 <button
                   type="button"
-                  class="btn btn-primary md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                  class="btn btn-primary btn-xs"
                   disabled={!serverUrl || addLinkBusy}
                   onClick$={async () => {
                     await onAddSearchResult$(result);
@@ -340,13 +340,13 @@ const SearchSection = component$(
             </div>
           ))}
         </div>
-        <div class="grid gap-2 sm:flex sm:flex-wrap">
+        <div class="flex flex-wrap gap-2">
           {serverUrl && (
             <a
               href={`${serverUrl}/magnets`}
               target="_blank"
               rel="noreferrer"
-              class="btn btn-ghost md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+              class="btn btn-ghost btn-sm flex-1 sm:flex-none"
             >
               /magnets
             </a>
@@ -356,7 +356,7 @@ const SearchSection = component$(
               href={`${serverUrl}/stat`}
               target="_blank"
               rel="noreferrer"
-              class="btn btn-ghost md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+              class="btn btn-ghost btn-sm flex-1 sm:flex-none"
             >
               /stat
             </a>
@@ -366,7 +366,7 @@ const SearchSection = component$(
               href={`${serverUrl}/playlistall/all.m3u`}
               target="_blank"
               rel="noreferrer"
-              class="btn btn-ghost md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+              class="btn btn-ghost btn-sm flex-1 sm:flex-none"
             >
               /playlistall
             </a>
@@ -429,7 +429,7 @@ const StorageSection = component$(
             </span>
             <select
               id="modal-storage-settings-mode"
-              class="select select-bordered min-h-11 w-full text-base"
+              class="select select-bordered w-full"
               value={storageDraftSettings.value}
               onChange$={(_, element) => {
                 storageDraftSettings.value =
@@ -446,7 +446,7 @@ const StorageSection = component$(
             </span>
             <select
               id="modal-storage-viewed-mode"
-              class="select select-bordered min-h-11 w-full text-base"
+              class="select select-bordered w-full"
               value={storageDraftViewed.value}
               onChange$={(_, element) => {
                 storageDraftViewed.value =
@@ -459,7 +459,7 @@ const StorageSection = component$(
           </label>
           <button
             type="button"
-            class="btn btn-outline min-h-11 w-full"
+            class="btn btn-outline w-full"
             disabled={!serverUrl || storageUpdateBusy}
             onClick$={onApplyStorage$}
           >
@@ -500,7 +500,7 @@ const StorageSection = component$(
           <div class="grid gap-2 sm:grid-cols-2">
             <button
               type="button"
-              class="btn btn-primary min-h-11"
+              class="btn btn-primary"
               disabled={!serverUrl || !selectedTorrentLabel || viewedActionBusy}
               onClick$={onMarkViewed$}
             >
@@ -508,7 +508,7 @@ const StorageSection = component$(
             </button>
             <button
               type="button"
-              class="btn btn-outline min-h-11"
+              class="btn btn-outline"
               disabled={!serverUrl || !selectedTorrentLabel || viewedActionBusy}
               onClick$={onRemoveViewed$}
             >

--- a/src/components/torrserver/torrserver-file-list-modal.tsx
+++ b/src/components/torrserver/torrserver-file-list-modal.tsx
@@ -1,10 +1,6 @@
 import { component$, type PropFunction } from "@builder.io/qwik";
 import { TorrServerModal } from "./torrserver-modal";
-import {
-  formatBytes,
-  getFileTitle,
-  getToneSurfaceClass,
-} from "./torrserver-utils";
+import { formatBytes, getFileTitle } from "./torrserver-utils";
 
 export type TorrServerFileEntry = {
   description?: string;
@@ -82,16 +78,16 @@ export const TorrServerFileListModal = component$(
             )}
           </div>
         ) : files.length === 0 ? (
-          <div
-            class={`rounded-box border p-5 text-sm shadow-none ${getToneSurfaceClass("neutral")}`}
-          >
-            <p class="font-semibold">{emptyTitle}</p>
-            <p class="text-base-content/70 mt-1 leading-relaxed">
-              {emptyDescription}
-            </p>
+          <div class="alert border-base-200 bg-base-200/40 shadow-none">
+            <div>
+              <p class="font-semibold">{emptyTitle}</p>
+              <p class="text-base-content/70 text-sm leading-relaxed">
+                {emptyDescription}
+              </p>
+            </div>
           </div>
         ) : (
-          <section class="space-y-3">
+          <div class="space-y-3">
             {files.map((file) => {
               const sizeLabel =
                 file.sizeLabel ?? formatBytes(file.size ?? null);
@@ -100,74 +96,74 @@ export const TorrServerFileListModal = component$(
               return (
                 <article
                   key={file.id}
-                  class="rounded-box border-base-200 bg-base-100 border p-4 shadow-sm"
+                  class="card border-base-200 bg-base-100 border shadow-sm"
                 >
-                  <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div class="min-w-0 space-y-3">
-                      <div class="flex flex-wrap items-center gap-2">
-                        <span class="badge badge-outline rounded-full px-3 py-3 font-medium">
+                  <div class="card-body gap-4 p-4">
+                    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div class="min-w-0 space-y-3">
+                        <span class="badge badge-outline rounded-full font-medium">
                           {sizeLabel}
                         </span>
+
+                        <div class="space-y-1">
+                          <h4 class="min-w-0 text-base font-semibold break-words md:text-lg">
+                            {titleLabel}
+                          </h4>
+                          {file.path && file.path !== titleLabel && (
+                            <p class="text-base-content/65 text-xs leading-relaxed break-all">
+                              {file.path}
+                            </p>
+                          )}
+                          {file.note && (
+                            <p class="text-base-content/70 text-sm leading-relaxed">
+                              {file.note}
+                            </p>
+                          )}
+                          {file.description && (
+                            <p class="text-base-content/60 text-xs leading-relaxed">
+                              {file.description}
+                            </p>
+                          )}
+                        </div>
                       </div>
 
-                      <div class="space-y-1">
-                        <h4 class="min-w-0 text-base font-semibold wrap-break-word md:text-lg">
-                          {titleLabel}
-                        </h4>
-                        {file.path && file.path !== titleLabel && (
-                          <p class="text-base-content/65 text-xs leading-relaxed break-all">
-                            {file.path}
-                          </p>
+                      <div class="flex flex-wrap gap-2">
+                        {onPlayFile$ && (
+                          <button
+                            type="button"
+                            class="btn btn-primary btn-sm flex-1 sm:flex-none"
+                            onClick$={async () => onPlayFile$(file)}
+                          >
+                            {playActionLabel}
+                          </button>
                         )}
-                        {file.note && (
-                          <p class="text-base-content/70 text-sm leading-relaxed">
-                            {file.note}
-                          </p>
+                        {file.streamUrl && onOpenStream$ && (
+                          <a
+                            href={file.streamUrl}
+                            class="btn btn-outline btn-sm flex-1 sm:flex-none"
+                            data-tip={streamTooltip}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            {streamActionLabel}
+                          </a>
                         )}
-                        {file.description && (
-                          <p class="text-base-content/60 text-xs leading-relaxed">
-                            {file.description}
-                          </p>
+                        {file.streamUrl && onCopyStreamUrl$ && (
+                          <button
+                            type="button"
+                            class="btn btn-ghost btn-sm flex-1 sm:flex-none"
+                            onClick$={async () => onCopyStreamUrl$(file)}
+                          >
+                            {copyActionLabel}
+                          </button>
                         )}
                       </div>
-                    </div>
-
-                    <div class="grid shrink-0 gap-2 sm:flex sm:flex-wrap">
-                      {onPlayFile$ && (
-                        <button
-                          type="button"
-                          class="btn btn-primary min-h-11 w-full rounded-full sm:w-auto md:btn-sm"
-                          onClick$={async () => onPlayFile$(file)}
-                        >
-                          {playActionLabel}
-                        </button>
-                      )}
-                      {file.streamUrl && onOpenStream$ && (
-                        <a
-                          href={file.streamUrl}
-                          class="btn btn-outline min-h-11 w-full rounded-full sm:w-auto md:btn-sm"
-                          data-tip={streamTooltip}
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          {streamActionLabel}
-                        </a>
-                      )}
-                      {file.streamUrl && onCopyStreamUrl$ && (
-                        <button
-                          type="button"
-                          class="btn btn-ghost min-h-11 w-full rounded-full sm:w-auto md:btn-sm"
-                          onClick$={async () => onCopyStreamUrl$(file)}
-                        >
-                          {copyActionLabel}
-                        </button>
-                      )}
                     </div>
                   </div>
                 </article>
               );
             })}
-          </section>
+          </div>
         )}
       </TorrServerModal>
     );

--- a/src/components/torrserver/torrserver-modal.tsx
+++ b/src/components/torrserver/torrserver-modal.tsx
@@ -77,14 +77,14 @@ export const TorrServerModal = component$(
               <button
                 type="submit"
                 aria-label={closeLabel}
-                class="btn btn-ghost btn-circle min-h-11 w-11 p-0"
+                class="btn btn-ghost btn-circle btn-sm"
               >
                 ✕
               </button>
             </form>
           </div>
 
-          <div class="space-y-4 px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:p-5 sm:pb-[calc(1.25rem+env(safe-area-inset-bottom))]">
+          <div class="px-4 py-4 sm:p-5">
             <Slot />
           </div>
         </div>

--- a/src/components/torrserver/torrserver-summary-card.tsx
+++ b/src/components/torrserver/torrserver-summary-card.tsx
@@ -55,18 +55,18 @@ export const TorrServerSummaryCard = component$(
             <div class="flex flex-wrap items-center gap-2">
               <span
                 title={endpoint}
-                class="badge badge-outline max-w-full truncate rounded-full px-3 py-3 font-medium"
+                class="badge badge-outline max-w-full truncate rounded-full font-medium"
               >
                 {endpoint}
               </span>
               {version && (
-                <span class="badge badge-neutral rounded-full px-3 py-3 font-medium">
+                <span class="badge badge-neutral rounded-full font-medium">
                   {version}
                 </span>
               )}
               {connectionLabel && (
                 <span
-                  class={`badge rounded-full px-3 py-3 font-medium ${getToneBadgeClass(statusTone)}`}
+                  class={`badge rounded-full font-medium ${getToneBadgeClass(statusTone)}`}
                 >
                   {connectionLabel}
                 </span>
@@ -96,13 +96,10 @@ export const TorrServerSummaryCard = component$(
                 const tone = metric.tone ?? "neutral";
 
                 return (
-                  <div
-                    class="stat min-w-0 overflow-hidden px-4 py-3"
-                    key={metric.label}
-                  >
+                  <div class="stat min-w-0 overflow-hidden" key={metric.label}>
                     <p class="stat-title truncate text-xs">{metric.label}</p>
                     <p
-                      class={`stat-value truncate text-xl ${getToneStatValueClass(tone)}`}
+                      class={`stat-value truncate text-lg ${getToneStatValueClass(tone)}`}
                     >
                       {metric.value}
                     </p>
@@ -123,7 +120,7 @@ export const TorrServerSummaryCard = component$(
                 return (
                   <span
                     key={badge.label}
-                    class={`badge rounded-full px-3 py-3 font-medium ${getToneBadgeClass(tone)}`}
+                    class={`badge rounded-full font-medium ${getToneBadgeClass(tone)}`}
                   >
                     {badge.label}
                   </span>

--- a/src/routes/(auth-guard)/torrserver/index.tsx
+++ b/src/routes/(auth-guard)/torrserver/index.tsx
@@ -951,29 +951,25 @@ export default component$(() => {
   /* ── Render ────────────────────────────────────────────── */
 
   return (
-    <div class="mx-auto w-full max-w-7xl space-y-6 pb-10">
+    <div class="mx-auto w-full max-w-7xl space-y-8 pb-10">
       <SectionHeading title={langTorrServer(lang)} />
 
-      <div class="grid min-w-0 gap-6">
+      <div class="space-y-8">
         {/* ── Connection workspace ─────────────────────────── */}
         <section class="card border-base-200 bg-base-100 border shadow-sm">
-          <div class="card-body gap-4 p-4 md:gap-5 md:p-6">
-            <div class="space-y-1">
-              <h2 class="card-title text-xl">
-                {langText(lang, "Servers", "Серверы")}
-              </h2>
-            </div>
+          <div class="card-body gap-5 p-4 md:p-6">
+            <h2 class="card-title">{langText(lang, "Servers", "Серверы")}</h2>
 
-            <Form onSubmit$={addTorrserver} class="space-y-2">
+            <Form onSubmit$={addTorrserver}>
               <Field name="ipaddress">
                 {(field, props) => (
                   <div class="space-y-2">
                     <div class="join join-vertical sm:join-horizontal w-full">
                       <label
-                        class="input input-bordered join-item flex w-full min-w-0 items-center gap-2 text-base"
+                        class="input input-bordered join-item flex w-full min-w-0 items-center gap-2"
                         for="torrserver-url"
                       >
-                        <span class="label text-base-content/65 shrink-0 text-xs font-medium tracking-[0.12em] uppercase">
+                        <span class="text-base-content/60 shrink-0 text-xs font-medium tracking-[0.12em] uppercase">
                           {langText(lang, "URL", "Адрес")}
                         </span>
                         <input
@@ -981,13 +977,13 @@ export default component$(() => {
                           id="torrserver-url"
                           type="url"
                           placeholder={langAddNewTorrServerURL(lang)}
-                          class="h-11 min-w-0 grow"
+                          class="min-w-0 grow"
                         />
                       </label>
                       <button
                         type="submit"
                         disabled={newTorrServerForm.invalid}
-                        class="btn btn-primary join-item min-h-11 w-full justify-center sm:w-32 sm:shrink-0"
+                        class="btn btn-primary join-item w-full sm:w-32 sm:shrink-0"
                       >
                         <HiPlusSolid class="text-lg" />
                         {langText(lang, "Add", "Добавить")}
@@ -1001,17 +997,15 @@ export default component$(() => {
               </Field>
             </Form>
 
-            <div class="space-y-2">
-              <label class="label px-0 pt-0" for="active-torrserver">
-                <span class="label-text font-medium">
-                  {langText(lang, "Active server", "Активный сервер")}
-                </span>
-              </label>
+            <label class="form-control">
+              <span class="label label-text px-0 pt-0">
+                {langText(lang, "Active server", "Активный сервер")}
+              </span>
               <div class="join join-vertical md:join-horizontal w-full">
                 <select
                   id="active-torrserver"
                   value={selectedTorServer.value}
-                  class="select select-bordered join-item h-11 min-h-11 w-full min-w-0 text-base"
+                  class="select select-bordered join-item w-full min-w-0"
                   onChange$={(_, el) => {
                     selectedTorServer.value = normalizeServer(el.value);
                     persistServersStorage({
@@ -1040,7 +1034,7 @@ export default component$(() => {
                   disabled={
                     !selectedTorServer.value || isCheckingTorrServer.value
                   }
-                  class="btn btn-outline join-item min-h-11 w-full justify-center md:w-28 md:shrink-0"
+                  class="btn btn-outline join-item w-full md:w-28 md:shrink-0"
                   onClick$={() => loadServerSnapshot(selectedTorServer.value)}
                 >
                   {langText(lang, "Refresh", "Обновить")}
@@ -1048,20 +1042,20 @@ export default component$(() => {
                 <button
                   type="button"
                   disabled={!selectedTorServer.value}
-                  class="btn btn-error btn-outline join-item min-h-11 w-full justify-center md:w-32 md:shrink-0"
+                  class="btn btn-error btn-outline join-item w-full md:w-32 md:shrink-0"
                   onClick$={removeActiveServer}
                 >
                   <HiMinusSolid class="text-lg" />
                   {langText(lang, "Remove", "Удалить")}
                 </button>
               </div>
-            </div>
+            </label>
 
             <div
               role="status"
               class={`alert ${connectionAlertClass(connectionState.value)}`}
             >
-              <div class="space-y-1">
+              <div>
                 <p class="font-semibold">
                   {connectionState.value === "connected"
                     ? langText(
@@ -1101,7 +1095,7 @@ export default component$(() => {
           metrics={summaryMetrics.value}
           badges={summaryBadges.value}
         >
-          <div class="grid min-w-0 gap-3 md:grid-cols-2">
+          <div class="grid gap-3 md:grid-cols-2">
             <div class="card border-base-200 bg-base-200/40 border shadow-none">
               <div class="card-body gap-2 p-4">
                 <p class="font-semibold">
@@ -1143,7 +1137,7 @@ export default component$(() => {
               </div>
             </div>
           </div>
-          <div class="grid gap-2 sm:flex sm:flex-wrap">
+          <div class="flex flex-wrap gap-2">
             {selectedTorServer.value && (
               <a
                 href={buildTorrentPlaylistUrl(
@@ -1153,7 +1147,7 @@ export default component$(() => {
                 )}
                 target="_blank"
                 rel="noreferrer"
-                class="btn btn-outline md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-outline btn-sm flex-1 sm:flex-none"
               >
                 {langText(
                   lang,
@@ -1167,14 +1161,14 @@ export default component$(() => {
                 href={`${selectedTorServer.value}/playlistall/all.m3u`}
                 target="_blank"
                 rel="noreferrer"
-                class="btn btn-ghost md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-ghost btn-sm flex-1 sm:flex-none"
               >
                 {langText(lang, "Full library M3U", "M3U всей библиотеки")}
               </a>
             )}
             <button
               type="button"
-              class="btn btn-outline md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+              class="btn btn-outline btn-sm flex-1 sm:flex-none"
               disabled={!selectedTorServer.value}
               onClick$={() => {
                 apiToolsModalOpen.value = true;

--- a/src/routes/(auth-guard)/torrserver/torrserver-card.tsx
+++ b/src/routes/(auth-guard)/torrserver/torrserver-card.tsx
@@ -50,16 +50,16 @@ export const TorrentCard = component$(
 
     return (
       <article class="card border-base-200 bg-base-100 min-w-0 border shadow-sm">
-        <div class="card-body gap-3 p-3 sm:gap-4 sm:p-4">
-          <div class="flex flex-wrap gap-2">
-            <span class="badge badge-outline badge-sm px-3 py-2">
+        <div class="card-body gap-4 p-4">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="badge badge-outline badge-sm">
               {torrent.mediaKind === "tv"
                 ? langText(lang, "Series", "Сериал")
                 : torrent.mediaKind === "movie"
                   ? langText(lang, "Movie", "Фильм")
                   : langText(lang, "Other", "Другое")}
             </span>
-            <span class="badge badge-ghost badge-sm px-3 py-2">
+            <span class="badge badge-ghost badge-sm">
               {statusBucket === "active"
                 ? langText(lang, "Active", "Активный")
                 : statusBucket === "database"
@@ -67,14 +67,14 @@ export const TorrentCard = component$(
                   : langText(lang, "Other", "Другое")}
             </span>
             {torrent.statusLabel && (
-              <span class="badge badge-outline badge-sm px-3 py-2 text-center leading-tight whitespace-normal">
+              <span class="badge badge-outline badge-sm whitespace-normal">
                 {torrent.statusLabel}
               </span>
             )}
-            <span class="badge badge-outline badge-sm px-3 py-2">
+            <span class="badge badge-outline badge-sm">
               {formatTorrentSize(torrent.torrent_size)}
             </span>
-            <span class="badge badge-outline badge-sm px-3 py-2">
+            <span class="badge badge-outline badge-sm">
               {langText(
                 lang,
                 `${torrent.fileCount} files`,
@@ -114,15 +114,15 @@ export const TorrentCard = component$(
             </div>
           )}
 
-          <div class="grid gap-3">
-            <div class="stats stats-vertical bg-base-200/45 sm:stats-horizontal w-full shadow-none">
-              <div class="stat min-w-0 overflow-hidden px-3 py-2">
+          <div class="grid gap-4">
+            <div class="stats stats-vertical bg-base-200/40 sm:stats-horizontal w-full shadow-none">
+              <div class="stat min-w-0 overflow-hidden px-4 py-3">
                 <div class="stat-title text-xs">
                   {langText(lang, "Peers", "Пиры")}
                 </div>
                 <div class="stat-value text-sm">{torrent.total_peers || 0}</div>
               </div>
-              <div class="stat min-w-0 overflow-hidden px-3 py-2">
+              <div class="stat min-w-0 overflow-hidden px-4 py-3">
                 <div class="stat-title text-xs">
                   {langText(lang, "Down", "Скач.")}
                 </div>
@@ -130,7 +130,7 @@ export const TorrentCard = component$(
                   {formatTransferSpeed(torrent.download_speed)}
                 </div>
               </div>
-              <div class="stat min-w-0 overflow-hidden px-3 py-2">
+              <div class="stat min-w-0 overflow-hidden px-4 py-3">
                 <div class="stat-title text-xs">
                   {langText(lang, "Up", "Отд.")}
                 </div>
@@ -140,14 +140,14 @@ export const TorrentCard = component$(
               </div>
             </div>
 
-            <p class="text-base-content/70 line-clamp-2 text-xs wrap-break-word">
+            <p class="text-base-content/70 line-clamp-2 text-xs break-words">
               {torrent.name || torrent.title}
             </p>
 
-            <div class="grid gap-2 sm:flex sm:flex-wrap">
+            <div class="flex flex-wrap gap-2">
               <button
                 type="button"
-                class="btn btn-primary md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-primary btn-sm flex-1 sm:flex-none"
                 onClick$={() => onOpenFiles$(torrent)}
               >
                 <LuFolderOpen class="text-base" />
@@ -157,7 +157,7 @@ export const TorrentCard = component$(
                 href={buildTorrentPlaylistUrl(serverUrl, torrent.hash)}
                 target="_blank"
                 rel="noreferrer"
-                class="btn btn-outline md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-outline btn-sm flex-1 sm:flex-none"
               >
                 <LuListMusic class="text-base" />
                 <span>{langText(lang, "Playlist", "Плейлист")}</span>
@@ -166,14 +166,14 @@ export const TorrentCard = component$(
                 href={buildMagnetFromHash(torrent.hash)}
                 target="_blank"
                 rel="noreferrer"
-                class="btn btn-info btn-outline md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-info btn-outline btn-sm flex-1 sm:flex-none"
               >
                 <LuMagnet class="text-base" />
                 <span>{langText(lang, "Magnet", "Магнет")}</span>
               </a>
               <button
                 type="button"
-                class="btn btn-warning btn-outline md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-warning btn-outline btn-sm flex-1 sm:flex-none"
                 onClick$={() => onDrop$(torrent)}
               >
                 <LuPause class="text-base" />
@@ -181,7 +181,7 @@ export const TorrentCard = component$(
               </button>
               <button
                 type="button"
-                class="btn btn-error btn-outline md:btn-sm min-h-11 w-full rounded-full sm:w-auto"
+                class="btn btn-error btn-outline btn-sm flex-1 sm:flex-none"
                 onClick$={() => onRemove$(torrent)}
               >
                 <LuTrash2 class="text-base" />

--- a/src/routes/(auth-guard)/torrserver/torrserver-filters.tsx
+++ b/src/routes/(auth-guard)/torrserver/torrserver-filters.tsx
@@ -46,13 +46,13 @@ export interface TorrServerFiltersProps {
 export const TorrServerFilters = component$(
   ({ lang, querySig, sortKeySig, statusFilterSig }: TorrServerFiltersProps) => (
     <section class="card border-base-200 bg-base-100 border shadow-sm">
-      <div class="card-body gap-4 p-4 md:gap-5 md:p-6">
+      <div class="card-body gap-5 p-4 md:p-6">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <h2 class="card-title">{langText(lang, "Filters", "Фильтры")}</h2>
 
           <div class="grid w-full min-w-0 gap-3 md:grid-cols-[minmax(0,18rem)_minmax(0,12rem)] lg:w-auto">
-            <label class="input input-bordered flex min-w-0 items-center gap-2 text-base">
-              <span class="text-base-content/60 text-xs font-medium tracking-[0.12em] uppercase">
+            <label class="input input-bordered flex min-w-0 items-center gap-2">
+              <span class="text-base-content/60 shrink-0 text-xs font-medium tracking-[0.12em] uppercase">
                 {langText(lang, "Search", "Поиск")}
               </span>
               <input
@@ -63,7 +63,7 @@ export const TorrServerFilters = component$(
                   "Search title, hash, category",
                   "Поиск по названию, hash, категории",
                 )}
-                class="h-11 min-w-0 grow"
+                class="min-w-0 grow"
                 onInput$={(_, element) => {
                   querySig.value = element.value;
                 }}
@@ -77,7 +77,7 @@ export const TorrServerFilters = component$(
                 "Sort TorrServer torrents",
                 "Сортировать торренты TorrServer",
               )}
-              class="select select-bordered h-11 min-h-11 text-base"
+              class="select select-bordered"
               onChange$={(_, element) => {
                 sortKeySig.value = element.value as TorrServerSortKey;
               }}
@@ -93,12 +93,12 @@ export const TorrServerFilters = component$(
           </div>
         </div>
 
-        <div class="grid gap-2 sm:flex sm:flex-wrap">
+        <div class="flex flex-wrap gap-2">
           {STATUS_FILTERS.map((filter) => (
             <button
               type="button"
               key={filter}
-              class={`btn md:btn-sm min-h-11 w-full sm:w-auto ${
+              class={`btn btn-sm flex-1 sm:flex-none ${
                 statusFilterSig.value === filter ? "btn-primary" : "btn-ghost"
               }`}
               onClick$={() => {


### PR DESCRIPTION
## Summary

UI/UX refactoring of the /torrserver page — no functionality changes, purely visual consistency improvements.

## Changes

- Standardized button sizing: replaced md:btn-sm min-h-11 rounded-full with consistent btn-sm flex-1 sm:flex-none pattern
- Badges: removed non-standard padding overrides, let DaisyUI defaults handle sizing
- Fixed non-Tailwind class: wrap-break-word → break-words
- Fixed non-standard opacity: bg-base-200/45 → bg-base-200/40
- DaisyUI patterns: used form-control for labels, alert for empty states, card/card-body for file items
- Consistent spacing: card-body gap-5 p-4 md:p-6 across all sections
- Cleaner modal: simplified close button and body padding
- Removed explicit sizing from inputs/selects

## Verification

- ✅ bun run build.types — passed
- ✅ bun run lint — passed
- ✅ bun run build — passed (SSR + SSG)
- ✅ bun test torrserver-state — 6/6 passed