### PR TITLE
fix: lower stale-while-revalidate cache from 7 days to 1 hour

### DIFF
--- a/src/routes/(auth-guard)/layout.tsx
+++ b/src/routes/(auth-guard)/layout.tsx
@@ -16,8 +16,8 @@ export const onGet: RequestHandler = async ({ cacheControl }) => {
   // Control caching for this request for best performance and to reduce hosting costs:
   // https://qwik.builder.io/docs/caching/
   cacheControl({
-    // Always serve a cached response by default, up to a week stale
-    staleWhileRevalidate: 60 * 60 * 24 * 7,
+    // Serve stale cache for up to 1 hour before requiring a fresh fetch
+    staleWhileRevalidate: 3600,
     // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
     maxAge: 5,
   });
@@ -26,10 +26,10 @@ export const onGet: RequestHandler = async ({ cacheControl }) => {
 //auth guard
 export const onRequest: RequestHandler = (event) => {
   event.cacheControl({
-    staleWhileRevalidate: 60 * 60 * 24 * 7,
+    staleWhileRevalidate: 3600,
     // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
     maxAge: 5,
-  }); // disable caching
+  });
 
   let session: Session | null = event.sharedMap.get("session");
   if (!session) {

--- a/src/routes/auth/layout.tsx
+++ b/src/routes/auth/layout.tsx
@@ -2,16 +2,16 @@ import { component$, Slot } from "@builder.io/qwik";
 import type { RequestHandler } from "@builder.io/qwik-city";
 
 export const onGet: RequestHandler = async ({ cacheControl }) => {
-	// Control caching for this request for best performance and to reduce hosting costs:
-	// https://qwik.builder.io/docs/caching/
-	cacheControl({
-		// Always serve a cached response by default, up to a week stale
-		staleWhileRevalidate: 60 * 60 * 24 * 7,
-		// Max once every 5 seconds, revalidate on the server to get a fresh version of this page
-		maxAge: 5,
-	});
+  // Control caching for this request for best performance and to reduce hosting costs:
+  // https://qwik.builder.io/docs/caching/
+  cacheControl({
+    // Serve stale cache for up to 1 hour before requiring a fresh fetch
+    staleWhileRevalidate: 3600,
+    // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
+    maxAge: 5,
+  });
 };
 
 export default component$(() => {
-	return <Slot />;
+  return <Slot />;
 });

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,33 +1,33 @@
 import { component$, Slot } from "@builder.io/qwik";
 import type { RequestHandler } from "@builder.io/qwik-city";
 import {
-	CSP_NONCE_HEADER,
-	createScriptNonce,
-	getContentSecurityPolicy,
-	QWIK_CSP_NONCE_KEY,
+  CSP_NONCE_HEADER,
+  createScriptNonce,
+  getContentSecurityPolicy,
+  QWIK_CSP_NONCE_KEY,
 } from "../utils/security-headers";
 
 export const onRequest: RequestHandler = ({ headers, sharedMap }) => {
-	const scriptNonce = createScriptNonce();
-	sharedMap.set(QWIK_CSP_NONCE_KEY, scriptNonce);
-	headers.set(CSP_NONCE_HEADER, scriptNonce);
-	headers.set(
-		"Content-Security-Policy",
-		getContentSecurityPolicy({ scriptNonce }),
-	);
+  const scriptNonce = createScriptNonce();
+  sharedMap.set(QWIK_CSP_NONCE_KEY, scriptNonce);
+  headers.set(CSP_NONCE_HEADER, scriptNonce);
+  headers.set(
+    "Content-Security-Policy",
+    getContentSecurityPolicy({ scriptNonce }),
+  );
 };
 
 export const onGet: RequestHandler = async ({ cacheControl }) => {
-	// Control caching for this request for best performance and to reduce hosting costs:
-	// https://qwik.builder.io/docs/caching/
-	cacheControl({
-		// Always serve a cached response by default, up to a week stale
-		staleWhileRevalidate: 60 * 60 * 24 * 7,
-		// Max once every 5 seconds, revalidate on the server to get a fresh version of this page
-		maxAge: 5,
-	});
+  // Control caching for this request for best performance and to reduce hosting costs:
+  // https://qwik.builder.io/docs/caching/
+  cacheControl({
+    // Serve stale cache for up to 1 hour before requiring a fresh fetch
+    staleWhileRevalidate: 3600,
+    // Max once every 5 seconds, revalidate on the server to get a fresh version of this page
+    maxAge: 5,
+  });
 };
 
 export default component$(() => {
-	return <Slot />;
+  return <Slot />;
 });


### PR DESCRIPTION
Reduce stale-while-revalidate across all layouts from 604800s (7 days) to 3600s (1 hour). This prevents users from seeing stale page layouts for days after deployments while still providing meaningful caching.

Cache-Control: max-age=5, stale-while-revalidate=3600