### PR TITLE
fix: skip gitleaks secret scan on workflow_call events

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -76,6 +76,7 @@ jobs:
 
   secrets:
     name: Secret scan
+    if: github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
gitleaks-action@v3 does not support the release event type. When quality.yml is called as a reusable workflow from deploy.yml (triggered by release), the secret scan fails. Fix: skip the secrets job when triggered via workflow_call, since the release has already passed gitleaks on PR merge.