### PR TITLE
fix: only run gitleaks on push and pull_request events

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -76,7 +76,7 @@ jobs:
 
   secrets:
     name: Secret scan
-    if: github.event_name != 'workflow_call'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
When quality.yml is called as a reusable workflow from deploy.yml (triggered by release), github.event_name inside the called workflow reflects the caller's event (release), not workflow_call. gitleaks-action does not support release events.\n\nFix: explicitly restrict the secrets job to push and pull_request events.