### PR TITLE
fix: add AUTH_TRUST_HOST for Cloud Run candidate deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
             --no-traffic \
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
-            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
+            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID,AUTH_TRUST_HOST=true" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
 

--- a/src/routes/auth-config.ts
+++ b/src/routes/auth-config.ts
@@ -78,6 +78,13 @@ export const resolveAuthTrustHost = ({
   lifecycleEvent,
   nodeEnv,
 }: Omit<AuthSecretContext, "authSecret"> & { authUrl?: string | null }) => {
+  // Explicit env override for Cloud Run candidate/preview deployments
+  // where AUTH_URL points to the production domain but requests arrive
+  // through *.a.run.app hostnames.
+  if (process.env.AUTH_TRUST_HOST === "true") {
+    return true;
+  }
+
   if (normalizeOrigin(authUrl)) {
     return true;
   }


### PR DESCRIPTION
Cloud Run candidate URLs (*.a.run.app) were rejected with 'Untrusted request origin' because the auth library checks the origin against AUTH_URL (moviestracker.net). \n\nFix: add AUTH_TRUST_HOST=true env var for deployments and check it in resolveAuthTrustHost so smoke tests can run against the candidate URL before promoting to the custom domain.