### PR TITLE
fix: pass production Host header to smoke test for candidate URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,9 +206,9 @@ jobs:
           trap rollback EXIT
           trap 'exit 130' INT TERM
 
-          ./scripts/smoke-deployment.sh "$CANDIDATE_URL"
+          ./scripts/smoke-deployment.sh "$CANDIDATE_URL" "${PROD_URL#https://}"
           gcloud run services update-traffic "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --to-revisions="$REVISION=10,$PREVIOUS=90" --quiet
-          ./scripts/smoke-deployment.sh "$CANDIDATE_URL"
+          ./scripts/smoke-deployment.sh "$CANDIDATE_URL" "${PROD_URL#https://}"
           gcloud run services update-traffic "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --to-revisions="$REVISION=100" --quiet
           ./scripts/smoke-deployment.sh "$URL"
 

--- a/scripts/smoke-deployment.sh
+++ b/scripts/smoke-deployment.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_url="${1:?usage: smoke-deployment.sh BASE_URL}"
+base_url="${1:?usage: smoke-deployment.sh BASE_URL [PROD_HOST]}"
 base_url="${base_url%/}"
+prod_host="${2:-}"
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 
@@ -17,6 +18,15 @@ curl_args=(
 	--retry-delay 2
 	--header "Cache-Control: no-cache"
 )
+
+# When smoke-testing a Cloud Run candidate URL, @auth/core may reject
+# requests because the Host header does not match AUTH_URL.  Pass the
+# production host as a second argument so curl sends the expected Host.
+# (trustHost: true is already set, but @auth/core still validates the
+# Origin/Host header against the configured AUTH_URL in some paths.)
+if [[ -n "$prod_host" ]]; then
+	curl_args+=(--header "Host: $prod_host")
+fi
 
 # --- Root endpoint: app is behind auth guard and redirects to /auth ---
 # Follow the redirect to verify the app serves content (not a 5xx crash).


### PR DESCRIPTION
@auth/core rejects requests from Cloud Run candidate URLs (*.a.run.app) even with trustHost:true. Fix: pass the production domain as a Host header to the smoke test script so it can verify the candidate revision.