### PR TITLE
fix: revert Host header in smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,9 +206,9 @@ jobs:
           trap rollback EXIT
           trap 'exit 130' INT TERM
 
-          ./scripts/smoke-deployment.sh "$CANDIDATE_URL" "${PROD_URL#https://}"
+          ./scripts/smoke-deployment.sh "$CANDIDATE_URL"
           gcloud run services update-traffic "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --to-revisions="$REVISION=10,$PREVIOUS=90" --quiet
-          ./scripts/smoke-deployment.sh "$CANDIDATE_URL" "${PROD_URL#https://}"
+          ./scripts/smoke-deployment.sh "$CANDIDATE_URL"
           gcloud run services update-traffic "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --to-revisions="$REVISION=100" --quiet
           ./scripts/smoke-deployment.sh "$URL"
 


### PR DESCRIPTION
The Host header trick routes through the domain mapping, bypassing the candidate tag. Revert to relying on the AUTH_TRUST_HOST code fix which correctly allows Cloud Run *.a.run.app origin.