### PR TITLE
fix: add TRUSTED_ORIGINS for Cloud Run candidate URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
             --no-traffic \
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
-            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID,AUTH_TRUST_HOST=true" \
+            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID,TRUSTED_ORIGINS=*.a.run.app" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
 


### PR DESCRIPTION
The Qwik SSR entry has its own origin validation that checks the request host against AUTH_URL or TRUSTED_ORIGINS. Cloud Run candidate URLs (*.a.run.app) were rejected because only AUTH_URL (moviestracker.net) was configured.\n\nFix: add TRUSTED_ORIGINS=*.a.run.app to allow smoke tests against candidate URLs before promoting to the custom domain.