### PR TITLE
fix: dynamically add candidate URL to TRUSTED_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,11 +164,26 @@ jobs:
             --no-traffic \
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
-            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID,TRUSTED_ORIGINS=*.a.run.app" \
+            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
 
           URL=$(gcloud run services describe "$PROD_SERVICE" --region="$GCP_REGION" --project="$GCP_PROJECT" --format=json | jq -r --arg tag "$TAG" '.status.traffic[] | select(.tag == $tag) | .url')
+          test -n "$URL" && test "$URL" != "null"
+          CANDIDATE_HOST="${URL#https://}"
+
+          # Add the candidate host to TRUSTED_ORIGINS so the smoke test can
+          # reach the candidate revision through its tagged *.a.run.app URL.
+          gcloud run deploy "$PROD_SERVICE" \
+            --image="$IMAGE" \
+            --region="$GCP_REGION" \
+            --project="$GCP_PROJECT" \
+            --no-traffic \
+            --tag="$TAG" \
+            --revision-suffix="$SUFFIX" \
+            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID,TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
+            --quiet
           test -n "$URL" && test "$URL" != "null"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "revision=$PROD_SERVICE-$SUFFIX" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The Qwik SSR entry uses exact host matching for trusted origins, so wildcards don't work. Fix: after deploying the candidate revision, extract the candidate URL hostname and redeploy with it added to TRUSTED_ORIGINS alongside the production URL.