### PR TITLE
fix: use ^ delimiter for gcloud --set-env-vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,7 +181,7 @@ jobs:
             --no-traffic \
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
-            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID,TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --set-env-vars="NODE_ENV=production^AUTH_URL=$PROD_URL^GOOGLE_ID=$GOOGLE_ID^TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
           test -n "$URL" && test "$URL" != "null"


### PR DESCRIPTION
gcloud's --set-env-vars uses comma as separator, so a TRUSTED_ORIGINS value containing https://... URLs with commas breaks the parser. Fix: use ^ as the delimiter for the second deploy command.