### PR TITLE
fix: use --update-env-vars for TRUSTED_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,6 +165,7 @@ jobs:
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
             --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
+            --update-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
 
@@ -181,7 +182,8 @@ jobs:
             --no-traffic \
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
-            --set-env-vars="NODE_ENV=production^AUTH_URL=$PROD_URL^GOOGLE_ID=$GOOGLE_ID^TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
+            --update-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
           test -n "$URL" && test "$URL" != "null"


### PR DESCRIPTION
gcloud's --set-env-vars uses comma as separator and can't handle URLs containing ://. Use --update-env-vars to set TRUSTED_ORIGINS as a single env var without comma parsing issues.