### PR TITLE
fix: use separate --set-env-vars flags for TRUSTED_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
             --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
-            --update-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --set-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
 
@@ -183,7 +183,7 @@ jobs:
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
             --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
-            --update-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --set-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
           test -n "$URL" && test "$URL" != "null"


### PR DESCRIPTION
gcloud's --set-env-vars and --update-env-vars both use comma as delimiter, so a URL containing commas (https://...) can't be included directly. Fix: use two separate --set-env-vars flags - one for base env vars, one for TRUSTED_ORIGINS with the comma-containing URL value.