### PR TITLE
fix: use --env-vars-file for TRUSTED_ORIGINS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
             --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
-            --set-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --env-vars-file=/tmp/candidate-env.yaml \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
 
@@ -174,6 +174,7 @@ jobs:
           CANDIDATE_HOST="${URL#https://}"
 
           # Add the candidate host to TRUSTED_ORIGINS so the smoke test can
+          printf 'TRUSTED_ORIGINS=https://%s,%s\n' "$CANDIDATE_HOST" "$PROD_URL" > /tmp/candidate-env.yaml
           # reach the candidate revision through its tagged *.a.run.app URL.
           gcloud run deploy "$PROD_SERVICE" \
             --image="$IMAGE" \
@@ -183,7 +184,7 @@ jobs:
             --tag="$TAG" \
             --revision-suffix="$SUFFIX" \
             --set-env-vars="NODE_ENV=production,AUTH_URL=$PROD_URL,GOOGLE_ID=$GOOGLE_ID" \
-            --set-env-vars="TRUSTED_ORIGINS=https://${CANDIDATE_HOST},$PROD_URL" \
+            --env-vars-file=/tmp/candidate-env.yaml \
             --update-secrets="AUTH_SECRET=AUTH_SECRET:latest,GOOGLE_SECRET=GOOGLE_SECRET:latest,MONGO_URI=MONGO_URI:latest,TMDB_API_KEY=TMDB_API_KEY:latest,GC_API_KEY=GC_API_KEY:latest" \
             --quiet
           test -n "$URL" && test "$URL" != "null"


### PR DESCRIPTION
gcloud's --set-env-vars uses dict parsing that chokes on URLs containing :// and commas. Write TRUSTED_ORIGINS to a temp YAML file and pass it with --env-vars-file instead.