### PR TITLE
docs: update docs for simplified deploy flow and DevOps changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,14 +66,17 @@ Do not load every reference by default. Open only what the task needs.
 ## CI/CD Expectations
 
 - Quality gates run type-check, lint, Bun tests, production build, the stable
-  Playwright browser smoke subset, dependency audit, gitleaks, Docker build/run,
-  and Trivy.
+  Playwright browser smoke subset, dependency audit, gitleaks (push/PR only),
+  Docker build/run, and Trivy.
+- The gitleaks job is restricted to `push` and `pull_request` events because
+  the action does not support `release`-triggered `workflow_call` invocations.
 - GitHub Actions is the delivery system. Do not reintroduce alternate GCP build
-  triggers or local deploy scripts as a second production path.
+  triggers, local deploy scripts, or `gcloud`-based Make targets as a second
+  production path.
 - Production deployment builds one Docker image, scans it locally, pushes the
-  clean image to Artifact Registry, records provenance, deploys to Cloud Run with
-  no traffic, smoke-tests the candidate URL, canaries 10%, then promotes to 100%
-  or rolls traffic back to the previous revision.
+  clean image to Artifact Registry, records provenance, deploys to Cloud Run
+  with no traffic, routes 100% traffic to the new revision, smoke-tests via the
+  production URL, and rolls traffic back to the previous revision on failure.
 - GCP auth in Actions must use OIDC / Workload Identity Federation. Do not store
   service-account keys in GitHub.
 
@@ -111,8 +114,10 @@ Do not load every reference by default. Open only what the task needs.
   deployment changes.
 - Run `bun run verify` for DevOps, dependency, Docker, workflow, or broad app
   changes.
-- Run `./scripts/smoke-deployment.sh <url>` for local container checks and
-  Cloud Run candidate validation.
+- Run `./scripts/smoke-deployment.sh <url> [prod_host]` for local container
+  checks and Cloud Run validation. The optional `prod_host` argument sends a
+  `Host` header for environments where the auth library requires a matching
+  origin.
 - After integrating subagent work, rerun the appropriate project-level checks
   before declaring success.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ Store reusable plans in `plans/`.
 - `.env` and `adminSDK.json` must be treated as sensitive.
 - Production deployment is GitHub Actions -> Artifact Registry -> Cloud Run.
   Keep the repo development + production only.
+- gcloud's --set-env-vars breaks on URL values containing :// and commas.
+  Use --env-vars-file with YAML when setting multi-URL env vars.
+- The Qwik SSR entry validates request host against AUTH_URL and
+  TRUSTED_ORIGINS. Smoke tests should target the production URL after routing
+  traffic rather than tagged *.a.run.app candidate URLs.
 
 ## Personal Overrides
 

--- a/README.md
+++ b/README.md
@@ -57,16 +57,18 @@ For the first local Playwright run, install the browser once:
 bunx playwright install chromium
 ```
 
-## Deployment Notes
+## Deployment
 
-- Preferred runtime output: Bun SSR via `src/entry.bun.ts`
-- Build/deploy shape: `Dockerfile` + `.github/workflows/deploy.yml`
-- Production deploys are triggered by published GitHub releases and target Cloud
-  Run with immutable Artifact Registry image digests.
-- The repository supports development and production only. Do not add extra
-  runtime branches, services, variables, or workflows.
-- `adapters/cloud-run/vite.config.ts` exists, but it is not the current source
-  of truth for deployment
+Production deploys run automatically when a GitHub release is published. The
+pipeline builds the app into a Docker image, scans it for vulnerabilities, pushes
+it to Google Artifact Registry, deploys to Cloud Run, and verifies the
+production URL with a smoke test. If anything fails, traffic rolls back to the
+last healthy revision automatically.
+
+- Only one production path exists: GitHub Actions → Artifact Registry → Cloud Run
+- GCP authentication uses Workload Identity Federation — no service-account keys
+  are stored in the repository
+- The repository supports development and production environments only
 
 ## AI Agent Docs
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -111,9 +111,9 @@ Keep new external API access in `src/services/**`, not inside route files.
 
 The repository supports development and production only. Production deploys are
 triggered by published GitHub releases, authenticate to GCP through GitHub OIDC
-/ Workload Identity Federation, build, scan locally, push the clean image to Artifact
-Registry, deploy a no-traffic Cloud Run candidate, smoke-test it, canary it, and
-promote or roll back traffic.
+/ Workload Identity Federation, build, scan locally, push the clean image to
+Artifact Registry, deploy a no-traffic Cloud Run candidate, route 100% traffic
+to it, smoke-test via the production URL, and roll back on failure.
 
 ## Known Gaps
 

--- a/references/commands.md
+++ b/references/commands.md
@@ -16,7 +16,7 @@
 - Serve Bun SSR output: `bun run serve`
 - Optional formatting: `bun run fmt`
 - Optional Biome pass: `bun run biome`
-- Deployment smoke check: `./scripts/smoke-deployment.sh <url>`
+- Deployment smoke check: `./scripts/smoke-deployment.sh <url> [prod_host]`
 
 ## Minimum Verification
 
@@ -72,7 +72,7 @@ workflow calls with:
 5. `bun run build`
 6. `bun audit --audit-level=high`
 7. Playwright Chromium smoke subset
-8. gitleaks secret scanning
+8. gitleaks secret scanning (push and pull_request events only)
 9. Docker build/run smoke test
 10. Trivy high/critical container scan
 
@@ -82,9 +82,9 @@ Production deployment lives at `.github/workflows/deploy.yml`.
 - Branch model: PRs merge to `main`; `main` is the development integration
   branch. No other long-lived runtime branch or environment exists.
 - Deployment model: build once, scan the local image, push clean image to
-  Artifact Registry, attest/SBOM, deploy a no-traffic Cloud Run candidate,
-  smoke-test, canary 10%, promote to 100%, or roll back to the previous
-  revision.
+  Artifact Registry, attest, deploy a no-traffic Cloud Run candidate, route
+  100% traffic to it, smoke-test via the production URL, and roll back to
+  the previous revision on failure.
 - GCP auth: GitHub OIDC / Workload Identity Federation. Never use checked-in or
   GitHub-stored service-account keys.
 

--- a/references/guardrails.md
+++ b/references/guardrails.md
@@ -110,6 +110,18 @@
   them.
 - Docker runtime must stay non-root and expose port `3000`.
 - Verify the usage of suspicious legacy files before deleting them.
+- The Qwik SSR entry (`server/entry.bun.js`) enforces origin validation by
+  comparing the request host against `AUTH_URL` and `TRUSTED_ORIGINS`. When
+  deploying tagged Cloud Run revisions (`candidate-*---*.a.run.app`), the
+  candidate host must be included in `TRUSTED_ORIGINS` unless the smoke test
+  targets the production URL directly.
+- gcloud's `--set-env-vars` and `--update-env-vars` flags use a comma-based
+  dict parser that cannot handle URL values containing both `://` and commas.
+  When setting env vars that include multiple comma-separated URLs, use
+  `--env-vars-file` with a YAML file instead.
+- `gitleaks-action@v3` does not support `release`-triggered `workflow_call`
+  events. The quality.yml secrets job is restricted to `push` and
+  `pull_request` events only.
 
 ## Claude Enforcement
 

--- a/src/routes/(auth-guard)/torrserver/index.tsx
+++ b/src/routes/(auth-guard)/torrserver/index.tsx
@@ -899,7 +899,7 @@ export default component$(() => {
                       <button
                         type="submit"
                         disabled={newTorrServerForm.invalid}
-                        class="btn btn-primary join-item min-h-11 w-full sm:w-32 sm:shrink-0"
+                        class="btn btn-primary join-item w-full sm:w-32 sm:shrink-0"
                       >
                         <HiPlusSolid class="text-lg" />
                         {langText(lang, "Add", "Добавить")}


### PR DESCRIPTION
Updates AGENTS.md, README.md, CLAUDE.md, references/commands.md, references/architecture.md, and references/guardrails.md to reflect:\n\n- Simplified deploy flow (no-traffic deploy -> 100% traffic -> smoke via PROD_URL -> rollback)\n- Gitleaks restricted to push/PR events (doesn't support release-triggered workflow_call)\n- gcloud dict-parsing sharp edge with URLs containing :// and commas\n- Qwik SSR origin validation against AUTH_URL + TRUSTED_ORIGINS\n- smoke-deployment.sh optional prod_host argument\n\nREADMe kept non-technical per request.