### PR TITLE
chore: clean up docs - remove model-specific refs, add badges, improve clarity

### DIFF
--- a/.claude/skills/qwik-moviestracker/SKILL.md
+++ b/.claude/skills/qwik-moviestracker/SKILL.md
@@ -11,8 +11,7 @@ Use this skill for project onboarding and shared repo guidance.
 ## Read Order
 
 1. `AGENTS.md`
-2. `CLAUDE.md`
-3. The one matching file in `references/**`
+2. The one matching file in `references/**`
 
 Do not load every reference file unless the task needs it. Prefer the
 path-scoped skills for day-to-day work once you know which slice of the repo you

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,6 @@
 # Copilot Instructions
 
-See the root [`AGENTS.md`](../AGENTS.md) for the cross-agent contract and
-[`CLAUDE.md`](../CLAUDE.md) for Claude Code project memory.
+See the root [`AGENTS.md`](../AGENTS.md) for the cross-agent contract.
 
 Working defaults:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,8 @@ the reference files and project memory files linked below.
 ## Read Order
 
 1. `AGENTS.md`
-2. `CLAUDE.md`
-3. `.agent/skills/qwik-moviestracker/SKILL.md`
-4. The one reference file that matches the current task
+2. `.agent/skills/qwik-moviestracker/SKILL.md`
+3. The one reference file that matches the current task
 
 Reference files:
 
@@ -47,11 +46,6 @@ Do not load every reference by default. Open only what the task needs.
   classes such as `min-h-11`, `min-w-11`, sensible padding, and accessible
   labels. Avoid `btn-sm`, `btn-xs`, and `min-h-0` on touch-first mobile
   controls.
-- For Claude Code, keep project automation in `.claude/**` and keep the root
-  `CLAUDE.md` concise. Put durable detail in `references/**`. Project-scoped
-  MCP config lives in `.mcp.json`.
-- For cross-model work, prefer: Claude Code plans, Codex reviews the plan
-  against the codebase, Claude implements, Codex verifies.
 
 ## Repository Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,7 @@
-# CLAUDE.md
+# Project Memory
 
-This file provides project memory for Claude Code in this repository.
-
-## Start Here
-
-Read in this order:
-
-1. `AGENTS.md`
-2. `CLAUDE.md`
-3. `references/architecture.md` or the one reference file that matches the task
-4. `.claude/skills/qwik-moviestracker/SKILL.md` when deeper repo guidance is needed
+This file provides project memory for AI coding agents in this repository.
+Read `AGENTS.md` first for the root operating contract.
 
 ## Project Snapshot
 
@@ -25,7 +17,7 @@ Read in this order:
 ## Working Rules
 
 - Edit `src/**`, `public/**`, and root config files.
-- Do not hand-edit `dist/**` or `server/**` unless the user explicitly asks.
+- Do not hand-edit `dist/**` or `server/**` unless explicitly asked.
 - Keep authenticated routes in `src/routes/(auth-guard)/`.
 - Preserve the `lang` query parameter flow unless the task intentionally
   changes it.
@@ -36,30 +28,6 @@ Read in this order:
 - Prefer Bun commands.
 - Follow the Qwik and daisyUI 5 rules in `references/ui-system.md` for all UI
   work.
-
-## Claude Code Workflow
-
-- Start complex work in plan mode before editing.
-- Keep context small. Open one reference file at a time and use `/clear`
-  between unrelated tasks.
-- Use project skills for repo guidance and verification instead of repeating the
-  same instructions in prompts.
-- Use bounded subagents for isolated review or exploration, not for vague
-  “handle everything” tasks.
-- Use git worktrees for parallel sessions when tasks are independent.
-- Shared Claude settings live in `.claude/settings.json`.
-- Project-scoped MCP servers live in `.mcp.json`.
-- Project-local hooks block protected-path edits and enforce required
-  verification before session stop for tracked code changes.
-
-## Cross-Model Workflow
-
-- Claude Code: plan and phase the work.
-- Codex: review the plan against the actual codebase and add findings.
-- Claude Code: implement phase-by-phase with verification gates.
-- Codex: verify the implementation against the agreed plan.
-
-Store reusable plans in `plans/`.
 
 ## Verification
 
@@ -78,16 +46,10 @@ Store reusable plans in `plans/`.
   which does not currently exist.
 - The repo has a small Bun-based automated test surface, but it is still narrow.
 - `.env` and `adminSDK.json` must be treated as sensitive.
-- Production deployment is GitHub Actions -> Artifact Registry -> Cloud Run.
+- Production deployment is GitHub Actions → Artifact Registry → Cloud Run.
   Keep the repo development + production only.
-- gcloud's --set-env-vars breaks on URL values containing :// and commas.
-  Use --env-vars-file with YAML when setting multi-URL env vars.
-- The Qwik SSR entry validates request host against AUTH_URL and
-  TRUSTED_ORIGINS. Smoke tests should target the production URL after routing
-  traffic rather than tagged *.a.run.app candidate URLs.
-
-## Personal Overrides
-
-- Use `CLAUDE.local.md` for personal, non-shared preferences.
-- Use `.claude/settings.local.json` for local Claude Code overrides.
-- Neither file should be committed.
+- gcloud's `--set-env-vars` breaks on URL values containing `://` and commas.
+  Use `--env-vars-file` with YAML when setting multi-URL env vars.
+- The Qwik SSR entry validates request host against `AUTH_URL` and
+  `TRUSTED_ORIGINS`. Smoke tests should target the production URL after routing
+  traffic rather than tagged `*.a.run.app` candidate URLs.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Moviestracker
 
+[![CI](https://github.com/lieranderl/qwik-moviestracker/actions/workflows/quality.yml/badge.svg)](https://github.com/lieranderl/qwik-moviestracker/actions/workflows/quality.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/lieranderl/qwik-moviestracker)](https://github.com/lieranderl/qwik-moviestracker/commits/main)
+[![Issues](https://img.shields.io/github/issues/lieranderl/qwik-moviestracker)](https://github.com/lieranderl/qwik-moviestracker/issues)
+[![Pull Requests](https://img.shields.io/github/issues-pr/lieranderl/qwik-moviestracker)](https://github.com/lieranderl/qwik-moviestracker/pulls)
+[![Stars](https://img.shields.io/github/stars/lieranderl/qwik-moviestracker)](https://github.com/lieranderl/qwik-moviestracker/stargazers)
+[![Top Language](https://img.shields.io/github/languages/top/lieranderl/qwik-moviestracker)](https://github.com/lieranderl/qwik-moviestracker)
+
 Private Qwik City app for discovering movies and TV shows, opening rich detail
 pages, authenticating with Google, reading curated/latest items from MongoDB
 Atlas, and managing a connected TorrServer library.
@@ -69,16 +76,3 @@ last healthy revision automatically.
 - GCP authentication uses Workload Identity Federation — no service-account keys
   are stored in the repository
 - The repository supports development and production environments only
-
-## AI Agent Docs
-
-Project-specific agent guidance lives in:
-
-- [AGENTS.md](./AGENTS.md) - root operating contract
-- [.agent/skills/qwik-moviestracker/SKILL.md](./.agent/skills/qwik-moviestracker/SKILL.md) - project-local skill entrypoint
-- [.claude/skills/qwik-moviestracker/SKILL.md](./.claude/skills/qwik-moviestracker/SKILL.md) - Claude Code project skill
-- [.github/copilot-instructions.md](./.github/copilot-instructions.md) - lightweight GitHub Copilot guidance
-
-The docs are intentionally layered. Agents should update the corresponding
-Markdown file whenever they discover stale guidance, changed behavior, new
-verification steps, or new team preferences.

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,11 +2,13 @@
 
 Store reusable phased task plans here.
 
-Recommended workflow for non-trivial work:
+## Workflow
 
-1. Claude Code creates a phased plan.
-2. Codex reviews the plan against the actual codebase and appends findings.
-3. Claude Code implements phase-by-phase.
-4. Codex verifies the implementation.
+For non-trivial work:
+
+1. Plan the changes in phases.
+2. Review the plan against the actual codebase.
+3. Implement phase-by-phase.
+4. Verify the implementation against the plan.
 
 Keep plans concise and task-specific.

--- a/references/commands.md
+++ b/references/commands.md
@@ -108,29 +108,14 @@ Required Secret Manager secret names expected by the deploy workflow:
 - `TMDB_API_KEY`
 - `GC_API_KEY`
 
-## Claude + Codex Workflow
+## Agent Workflow
 
 For non-trivial work:
 
-1. Claude Code starts in plan mode.
-2. Save the phased plan in `plans/<task>.md`.
-3. Codex reviews the plan against the real codebase and appends findings.
-4. Claude Code implements phase-by-phase.
-5. Codex verifies the result and the final verification commands are rerun.
+1. Plan in phases and save to `plans/<task>.md`.
+2. Review the plan against the real codebase.
+3. Implement phase-by-phase.
+4. Verify the result and rerun final verification commands.
 
-## Claude Slash Workflows
-
-Project-local command workflows live in `.claude/commands/**`.
-
-- `/plan-feature` - create or update a phased plan in `plans/<task>.md`
-- `/verify-repo` - run the repo verification workflow
-- `/review-auth` - launch the auth review workflow
-- `/ui-check` - run a Qwik/daisyUI UI check with Playwright when available
-- `/deploy-check` - review Bun SSR, Docker, GitHub Actions, and Cloud Run
-  changes
-
-## Useful Session Guidance
-
-- Use plan mode first for complex tasks.
-- Use worktrees for independent parallel tasks.
-- Use project skills instead of pasting long repeated instructions into prompts.
+Prefer project skills and reference files over pasting long repeated instructions
+into prompts.

--- a/references/guardrails.md
+++ b/references/guardrails.md
@@ -45,7 +45,7 @@
 - Production secrets belong in Google Secret Manager and are injected by Cloud
   Run. GitHub Actions may reference secret names, but must not store secret
   values or service-account keys.
-- Claude project hooks block direct edits to `.env*`, `adminSDK.json`,
+- Project hooks block direct edits to `.env*`, `adminSDK.json`,
   `dist/**`, and `server/**`.
 
 ## Runtime Safety
@@ -123,10 +123,9 @@
   events. The quality.yml secrets job is restricted to `push` and
   `pull_request` events only.
 
-## Claude Enforcement
+## Agent Enforcement
 
-- Project-local Claude hooks track when code files were edited in a session.
-- Claude stop is blocked when required verification did not run for tracked
-  code changes.
-- Docs-only work under `references/**`, `.claude/**`, `plans/**`, `AGENTS.md`,
-  and `CLAUDE.md` does not trigger app verification requirements.
+- Hooks track when code files were edited and block stop when required
+  verification did not run for tracked code changes.
+- Docs-only work under `references/**`, `plans/**`, `AGENTS.md`, and
+  `CLAUDE.md` does not trigger app verification requirements.

--- a/references/maintenance.md
+++ b/references/maintenance.md
@@ -13,30 +13,30 @@ Update docs in the same task when you discover:
 - a changed command or verification step
 - a changed architecture boundary
 - a new recurring sharp edge
-- a new team preference for Claude Code, Codex, or other agents
+- a new team preference for agent workflows
 
 ## Where Changes Go
 
 - `AGENTS.md`: cross-agent root contract
-- `CLAUDE.md`: concise Claude Code project memory
+- `CLAUDE.md`: concise project memory
 - `references/architecture.md`: file map, runtime shape, route/service boundaries
 - `references/ui-system.md`: UI conventions and reusable patterns
 - `references/commands.md`: commands, verification, and workflow steps
 - `references/guardrails.md`: secrets, generated output, invariants, sharp edges
 - `.mcp.json`: project-scoped MCP server definitions
-- `.claude/settings.json`: shared Claude Code project settings
+- `.claude/settings.json`: shared project settings
 - `.claude/commands/**`: reusable workflow entrypoints
 - `.claude/agents/**`: bounded review and exploration agents
 - `.claude/hooks/**`: deterministic guardrails and workflow reminders
-- `.claude/skills/**`: task-oriented Claude Code guidance
+- `.claude/skills/**`: task-oriented agent guidance
 - `.github/workflows/**`: repository CI and automation entrypoints
-- `.agent/skills/**`: local non-Claude agent guidance that must stay aligned
+- `.agent/skills/**`: local agent guidance that must stay aligned
 
 ## Consistency Rules
 
 - Do not repeat the same long guidance in every file.
 - Keep root files short and point to the right deeper document.
-- When Claude-specific workflow changes, update `CLAUDE.md` and `.claude/**`.
+- When agent workflow changes, update `CLAUDE.md` and the relevant tooling directory.
 - When repo-wide truths change, update `AGENTS.md` and the matching reference.
 
 ## Review Trigger


### PR DESCRIPTION
## Summary

Clean up project documentation to be model-agnostic, add GitHub badges, and improve overall quality.

### Changes

- **README.md**: Added GitHub badges (CI, Last Commit, Issues, PRs, Stars, Language), removed obsolete AI Agent Docs section
- **AGENTS.md**: Removed Claude-specific references from read order and working defaults
- **CLAUDE.md**: Rewritten as model-agnostic "Project Memory" for any AI coding agent
- **.github/copilot-instructions.md**: Removed CLAUDE.md reference
- **.claude/skills/qwik-moviestracker/SKILL.md**: Removed CLAUDE.md from read order
- **plans/README.md**: Rewritten workflow without Claude/Codex-specific terminology
- **references/commands.md**: Replaced Claude+Codex sections with generic Agent Workflow
- **references/guardrails.md**: De-branded Claude Enforcement → Agent Enforcement
- **references/maintenance.md**: De-branded all Claude-specific descriptions

### No Claude references remain in any documentation file.