### PR TITLE
fix(ci): bypass setup-gcloud token refresh failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,10 +65,11 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          project_id: ${{ env.GCP_PROJECT }}
+      - name: Setup gcloud project
+        run: |
+          # Avoid setup-gcloud action's gcloud config set project which can fail on WIF token refresh.
+          # Use CLOUDSDK_CORE_PROJECT env var to set project without triggering a token refresh.
+          echo "CLOUDSDK_CORE_PROJECT=${GCP_PROJECT}" >> "$GITHUB_ENV"
 
       - name: Configure Artifact Registry authentication
         run: gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
@@ -138,10 +139,9 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          project_id: ${{ env.GCP_PROJECT }}
+      - name: Setup gcloud project
+        run: |
+          echo "CLOUDSDK_CORE_PROJECT=${GCP_PROJECT}" >> "$GITHUB_ENV"
 
       - name: Deploy, smoke-test, and promote
         env:


### PR DESCRIPTION
## Problem

The `google-github-actions/setup-gcloud@v3` action runs `gcloud config set project` which triggers a WIF token refresh. This intermittently fails with:

```
ERROR: (gcloud.config.set) There was a problem refreshing your current auth tokens:
('Unable to retrieve Identity Pool subject token', 'upstream connect error or disconnect/reset before headers. reset reason: overflow')
```

## Fix

Replace `setup-gcloud@v3` with setting `CLOUDSDK_CORE_PROJECT` env var, which achieves the same result without triggering a token refresh.

The `auth@v3` step already handles authentication — we just need the project to be set for subsequent `gcloud` commands.